### PR TITLE
Enforce queue limit for mint requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,7 @@ The bot exposes several Discord slash commands:
 ## Monitoring
 When `ENABLE_PERFORMANCE_MONITORING` is `true`, a Prometheus metrics endpoint is
 exposed at `/metrics` on the port defined by `METRICS_PORT` (default `9090`).
+
+## Queue Limits
+The mint queue will hold at most `MAX_QUEUE_SIZE` requests (defaults to `1000`).
+Additional requests are dropped once the limit is exceeded.

--- a/src/modules/mint/queue.ts
+++ b/src/modules/mint/queue.ts
@@ -32,10 +32,17 @@ export class MintQueue extends EventEmitter {
   }
 
   add(request: MintRequest) {
+    if (this.length >= config.maxQueueSize) {
+      if (this.listenerCount('error') > 0) {
+        this.emit('error', new Error('Mint queue limit exceeded'));
+      }
+      return false;
+    }
     const queue = request.priority === 'premium' ? this.premiumQueue : this.basicQueue;
     queue.push({ ...request, attempts: request.attempts ?? 0 });
     this.emit('queued', request);
     if (!this.timer) this.start();
+    return true;
   }
 
   private start() {


### PR DESCRIPTION
## Summary
- prevent the mint queue from growing beyond `MAX_QUEUE_SIZE`
- document the queue limit in the README

## Testing
- `npm test` *(fails: Prisma requires DATABASE_URL and PostgreSQL)*

------
https://chatgpt.com/codex/tasks/task_e_6844e854ca608330a43bd284932b5232