### PR TITLE
Add Python requirements for coin sniper tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,7 @@ exposed at `/metrics` on the port defined by `METRICS_PORT` (default `9090`).
 
 ## Running Tests
 The test suite relies on dev dependencies such as `ts-node`.
-The `scripts/run-tests.sh` script automatically installs packages with `npm ci`
-if `node_modules` is missing, then executes all TypeScript, Rust and Python
-tests:
+The `scripts/run-tests.sh` script installs Node dependencies with `npm ci` if `node_modules` is missing, installs Python packages from `src/modules/coin_sniper/requirements.txt`, and then executes all TypeScript, Rust and Python tests:
 
 ```bash
 npm run test

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -6,6 +6,9 @@ if [ ! -d node_modules ]; then
   echo "Installing npm dependencies..."
   npm ci
 fi
+
+# Install Python requirements for the coin sniper module
+pip install -r src/modules/coin_sniper/requirements.txt
 MOCK_CACHE=1 TS_NODE_COMPILER_OPTIONS='{"module":"commonjs"}' TS_NODE_TRANSPILE_ONLY=1 node -r ts-node/register -r tsconfig-paths/register ./node_modules/mocha/bin/_mocha tests/**/*.test.ts
 cargo test --manifest-path src/modules/nft_mint_bot/Cargo.toml
 pytest src/modules/coin_sniper/tests

--- a/src/modules/coin_sniper/requirements.txt
+++ b/src/modules/coin_sniper/requirements.txt
@@ -1,0 +1,2 @@
+web3
+eth-account


### PR DESCRIPTION
## Summary
- add coin sniper `requirements.txt`
- install python deps in test script
- document Python requirement install in README

## Testing
- `npm run test` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_6844ea8289108330b2f32bb60e8ad3f1