### PR TITLE
Enforce queue size per priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,9 @@ npm run test
 
 
 ## Queue Limits
-The mint queue will hold at most `MAX_QUEUE_SIZE` requests (defaults to `1000`).
-Additional requests are dropped once the limit is exceeded.
+The mint queue will hold at most `MAX_QUEUE_SIZE` requests per priority
+(defaults to `1000`). When a queue is full, calls to `add()` return `false`
+and emit an `error` event.
 Detection opportunities are emitted when a project's score meets `DETECTION_SCORE_THRESHOLD` (default `1`).
 
 

--- a/src/modules/mint/queue.ts
+++ b/src/modules/mint/queue.ts
@@ -32,13 +32,13 @@ export class MintQueue extends EventEmitter {
   }
 
   add(request: MintRequest) {
-    if (this.length >= config.maxQueueSize) {
+    const queue = request.priority === 'premium' ? this.premiumQueue : this.basicQueue;
+    if (queue.length >= config.maxQueueSize) {
       if (this.listenerCount('error') > 0) {
         this.emit('error', new Error('Mint queue limit exceeded'));
       }
       return false;
     }
-    const queue = request.priority === 'premium' ? this.premiumQueue : this.basicQueue;
     queue.push({ ...request, attempts: request.attempts ?? 0 });
     this.emit('queued', request);
     if (!this.timer) this.start();


### PR DESCRIPTION
## Summary
- reject new mint requests when their priority queue exceeds `maxQueueSize`
- note queue limit behaviour in README

## Testing
- `npm run test` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_6844ea90555c8330a5753894e8b82b0d