### PR TITLE
Add env variable examples and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,8 +31,8 @@ MAX_QUEUE_SIZE=2000
 QUEUE_PROCESSING_INTERVAL_MS=50
 CONNECTION_POOL_SIZE=100
 REQUEST_TIMEOUT_MS=8000
-MINT_MAX_RETRIES=2
-GAS_MULTIPLIER=1.2
+MINT_MAX_RETRIES=2 # number of times to retry a failed mint
+GAS_MULTIPLIER=1.2 # increase to speed up replacement transactions
 
 # Predictive Failure Prevention
 ENABLE_BALANCE_PRECHECK=true
@@ -66,7 +66,7 @@ ENABLE_PERFORMANCE_MONITORING=true
 ALERT_ON_HIGH_FAILURE_RATE=true
 FAILURE_RATE_THRESHOLD=0.15
 METRICS_PORT=9090
-DETECTION_SCORE_THRESHOLD=1
+DETECTION_SCORE_THRESHOLD=1 # emit detection opportunities when score >= value
 
 # Payment Integration (if using on-chain payments)
 PAYMENT_TOKEN_ADDRESS=0x...
@@ -82,7 +82,7 @@ PRIVATE_KEY=
 CONTRACT_ADDRESS=
 ROUTER_ADDRESS=
 WETH_ADDRESS=
-USE_FLASHBOTS=false
+USE_FLASHBOTS=false # enable to submit transactions via Flashbots
 
 # Twitter OAuth
 TWITTER_CLIENT_ID=

--- a/README.md
+++ b/README.md
@@ -68,9 +68,10 @@ WEBSOCKET_RPC_URL=wss://mainnet.infura.io/ws/v3/your_key
 The bot will automatically switch providers on failure and stream new blocks when a WebSocket URL is provided.
 
 Additional options:
-- `GAS_MULTIPLIER` adjusts gas fees for replacement transactions (default `1.2`).
-- `MINT_MAX_RETRIES` controls how many times a failed mint is retried (default `2`).
-- Set `USE_FLASHBOTS=true` to route transactions through Flashbots.
+- `GAS_MULTIPLIER` adjusts gas fees for replacement transactions (default `1.2`). Increase this value if replacement transactions are frequently underpriced.
+- `MINT_MAX_RETRIES` sets how many times the bot will attempt a failed mint before giving up (default `2`).
+- `USE_FLASHBOTS` routes transactions through Flashbots for private bundle submission. Enable when you want MEV protection or to bypass the public mempool.
+- `DETECTION_SCORE_THRESHOLD` defines the minimum score required before a detection opportunity is emitted (default `1`).
 
 ## Available Commands
 The bot exposes several Discord slash commands:


### PR DESCRIPTION
## Summary
- document gas multiplier and retries in `.env.example`
- explain new configuration variables in README

## Testing
- `npm run test` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_6844ea915c2c8330b65f8ec205e262de