### PR TITLE
Fix nft mint bot build and tests

### DIFF
--- a/src/modules/nft_mint_bot/src/lib.rs
+++ b/src/modules/nft_mint_bot/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod config;

--- a/src/modules/nft_mint_bot/src/main.rs
+++ b/src/modules/nft_mint_bot/src/main.rs
@@ -33,8 +33,12 @@ async fn main() -> Result<()> {
 
     let contract_addr: Address = cfg.contract_address.parse()?;
     let contract = MintContract::new(contract_addr, client.clone());
-    let tx = contract.mint(address).send().await?;
-    let receipt = tx.await?.transaction_hash;
-    println!("✅ Minted in tx: {:#x}", receipt);
+    let call = contract.mint(address);
+    let tx = call.send().await?;
+    match tx.await? {
+        Some(receipt) => println!("✅ Minted in tx: {:#x}", receipt.transaction_hash),
+        None => println!("❌ Transaction dropped"),
+    }
     Ok(())
 }
+

--- a/tests/connect_confirm.test.ts
+++ b/tests/connect_confirm.test.ts
@@ -7,6 +7,8 @@ import { execute as connect } from '../src/domains/web3/commands/connect-wallet'
 import { execute as confirm } from '../src/domains/web3/commands/confirm-wallet';
 import { ethers } from 'ethers';
 
+process.env.SIGNATURE_MESSAGE = 'Authorize mint bot access';
+
 function mockInteraction(opts: any) {
   return {
     options: {


### PR DESCRIPTION
## Summary
- handle optional receipt in nft mint bot and avoid temporary value drop
- expose config via new `lib.rs`
- set `SIGNATURE_MESSAGE` in wallet connect test so signature verifies

## Testing
- `npm run test`
- `cargo test --manifest-path src/modules/nft_mint_bot/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_e_6845403144f48330bca6f00699dd006b