### PR TITLE
Fix mint-fast binary path

### DIFF
--- a/src/domains/web3/commands/mint-fast.ts
+++ b/src/domains/web3/commands/mint-fast.ts
@@ -11,7 +11,10 @@ export const data = new SlashCommandBuilder()
 
 export async function execute(interaction: ChatInputCommandInteraction) {
   const to = interaction.options.getString('to', true);
-  const bin = path.resolve(__dirname, '../../../../modules/nft_mint_bot/target/release/nft_mint_bot');
+  const bin = path.resolve(
+    __dirname,
+    '../../../../src/modules/nft_mint_bot/target/release/nft_mint_bot'
+  );
 
   const child = spawn(bin, [to]);
   let output = '';

--- a/src/modules/nft_mint_bot/src/main.rs
+++ b/src/modules/nft_mint_bot/src/main.rs
@@ -33,8 +33,11 @@ async fn main() -> Result<()> {
 
     let contract_addr: Address = cfg.contract_address.parse()?;
     let contract = MintContract::new(contract_addr, client.clone());
-    let tx = contract.mint(address).send().await?;
-    let receipt = tx.await?.transaction_hash;
+    // keep the call alive until the transaction is awaited
+    let call = contract.mint(address);
+    let tx = call.send().await?;
+    // `await` returns `Option<TransactionReceipt>`; unwrap before accessing hash
+    let receipt = tx.await?.unwrap().transaction_hash;
     println!("✅ Minted in tx: {:#x}", receipt);
     Ok(())
 }


### PR DESCRIPTION
## Summary
- point `mint-fast` command to `src/modules/nft_mint_bot`
- update Rust mint bot to compile on latest ethers

## Testing
- `cargo build --manifest-path src/modules/nft_mint_bot/Cargo.toml --release`
- `node -e "const {spawn}=require('child_process'); const path=require('path'); const bin=path.resolve('src/modules/nft_mint_bot/target/release/nft_mint_bot'); console.log('bin',bin); const child=spawn(bin,['0x0000000000000000000000000000000000000000'], {env:{}}); child.stdout.on('data',d=>process.stdout.write(d)); child.stderr.on('data',d=>process.stderr.write(d)); child.on('close',code=>console.log('exit',code));"`
- `npm test` *(fails: prisma engine postinstall ECONNRESET)*

------
https://chatgpt.com/codex/tasks/task_e_68459b8e9b6c83309f2ba3ffdb09c2dc