### PR TITLE
Add deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ to perform a mint.
 
 See `docs/nft_mint_bot.md` for a deeper explanation of the mint bot and how to
 extend it. Environment variables can be configured using the included
-`.env.example` file.
+`.env.example` file. For deployment steps consult `docs/deployment.md`.
 
 ## Command Restrictions & Info
 Commands can be limited to specific channels using `/restrict-command`. Admins

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,18 @@
+# Deployment Guide
+
+This guide walks through preparing your environment and running the bot.
+
+1. Copy `.env.example` to `.env` and fill in all required values.
+2. Install dependencies with `pnpm install` (or `npm ci`).
+3. Generate the Prisma client:
+   ```bash
+   pnpm exec prisma generate
+   ```
+4. Build the Rust mint bot binary:
+   ```bash
+   cargo build --release -p nft_mint_bot
+   ```
+5. Start the bot locally with `pnpm run dev` or use Docker:
+   ```bash
+   docker-compose up
+   ```


### PR DESCRIPTION
## Summary
- document local deployment steps
- reference deployment guide from README

## Testing
- `npm run test` *(fails: could not compile `nft_mint_bot`)*

------
https://chatgpt.com/codex/tasks/task_e_68459e2ce17c8330888116a520ffe5c2