### PR TITLE
Fix RPC_URL docs and support HTTP endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,7 +77,8 @@ PREMIUM_SUBSCRIPTION_PRICE=150
 
 
 # Web3 configuration
-RPC_URL=https://eth.llamarpc.com
+# RPC_URL must be a WebSocket endpoint for the Rust mint bot
+RPC_URL=wss://eth.llamarpc.com
 PRIVATE_KEY=
 CONTRACT_ADDRESS=
 ROUTER_ADDRESS=

--- a/docs/nft_mint_bot.md
+++ b/docs/nft_mint_bot.md
@@ -21,7 +21,7 @@ command.
 
 ## Environment
 The bot requires the following variables (see `.env.example`):
-- `RPC_URL` – JSON-RPC endpoint
+- `RPC_URL` – WebSocket JSON-RPC endpoint used by the Rust bot (e.g. `wss://...`)
 - `PRIVATE_KEY` – private key used to sign transactions
 - `CONTRACT_ADDRESS` – address of the mint contract
 

--- a/src/modules/nft_mint_bot/src/main.rs
+++ b/src/modules/nft_mint_bot/src/main.rs
@@ -26,10 +26,14 @@ async fn main() -> Result<()> {
     println!("✅ Config loaded: {}", cfg.rpc_url);
     println!("🚀 Minting to: {}", recipient);
 
-    let provider = Provider::<Ws>::connect(cfg.rpc_url).await?;
     let wallet: LocalWallet = cfg.private_key.parse()?;
-    let client = SignerMiddleware::new(provider, wallet);
-    let client = Arc::new(client);
+    let client: Arc<dyn Middleware> = if cfg.rpc_url.starts_with("ws") {
+        let provider = Provider::<Ws>::connect(&cfg.rpc_url).await?;
+        Arc::new(SignerMiddleware::new(provider, wallet.clone()))
+    } else {
+        let provider = Provider::<Http>::try_from(cfg.rpc_url.as_str())?;
+        Arc::new(SignerMiddleware::new(provider, wallet.clone()))
+    };
 
     let contract_addr: Address = cfg.contract_address.parse()?;
     let contract = MintContract::new(contract_addr, client.clone());


### PR DESCRIPTION
## Summary
- update docs to note RPC_URL must be a WebSocket URL for the Rust mint bot
- clarify RPC_URL example in `.env.example`
- allow the Rust mint bot to work with either WS or HTTP providers

## Testing
- `npm test` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68459e2a3be0833091f7296ddd7d2de3