### PR TITLE
Add Prisma client generation step

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A CLI-generated Discord bot in TypeScript with domain-based modular structure.
 
 ```bash
 pnpm install
+pnpm exec prisma generate
 pnpm run dev
 ```
 
@@ -101,7 +102,8 @@ exposed at `/metrics` on the port defined by `METRICS_PORT` (default `9090`).
 The test suite relies on dev dependencies such as `ts-node`.
 
 The `scripts/run-tests.sh` script will run `pnpm install` (or `npm ci`) when
-`node_modules` is missing, then execute the TypeScript, Rust and Python tests.
+`node_modules` is missing, generate the Prisma client, and then execute the
+TypeScript, Rust and Python tests.
 If `cargo` or `pytest` are not available they are skipped gracefully:
 
 ```bash

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -14,6 +14,13 @@ if [ ! -d node_modules ]; then
   fi
 fi
 
+# Ensure the Prisma client is generated
+if command -v pnpm >/dev/null 2>&1; then
+  pnpm exec prisma generate
+else
+  npx prisma generate
+fi
+
 # Install Python requirements for the coin sniper module
 pip install -r src/modules/coin_sniper/requirements.txt
 MOCK_CACHE=1 TS_NODE_COMPILER_OPTIONS='{"module":"commonjs"}' TS_NODE_TRANSPILE_ONLY=1 node -r ts-node/register -r tsconfig-paths/register ./node_modules/mocha/bin/_mocha tests/**/*.test.ts


### PR DESCRIPTION
## Summary
- document Prisma client generation in the quickstart and test instructions
- auto-generate Prisma client before running tests

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68459b9164d883308eaf5de14b598843