### PR TITLE
Enhance NFT mint bot gas handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,7 +32,7 @@ QUEUE_PROCESSING_INTERVAL_MS=50
 CONNECTION_POOL_SIZE=100
 REQUEST_TIMEOUT_MS=8000
 MINT_MAX_RETRIES=2 # number of times to retry a failed mint
-GAS_MULTIPLIER=1.2 # increase to speed up replacement transactions
+GAS_MULTIPLIER=1.2 # increase to speed up replacement transactions (mint bot uses this)
 
 # Predictive Failure Prevention
 ENABLE_BALANCE_PRECHECK=true
@@ -84,6 +84,8 @@ CONTRACT_ADDRESS=
 ROUTER_ADDRESS=
 WETH_ADDRESS=
 USE_FLASHBOTS=false # enable to submit transactions via Flashbots
+# Gas multiplier applied to EIP-1559 fees
+# GAS_MULTIPLIER also applies here if set above
 
 # Twitter OAuth
 TWITTER_CLIENT_ID=

--- a/docs/nft_mint_bot.md
+++ b/docs/nft_mint_bot.md
@@ -24,6 +24,7 @@ The bot requires the following variables (see `.env.example`):
 - `RPC_URL` – WebSocket JSON-RPC endpoint used by the Rust bot (e.g. `wss://...`)
 - `PRIVATE_KEY` – private key used to sign transactions
 - `CONTRACT_ADDRESS` – address of the mint contract
+- `GAS_MULTIPLIER` – multiplier applied to provider fee data when sending transactions
 
 ## Adding Logic
 Open `src/modules/nft_mint_bot/src/main.rs` and implement your minting logic.

--- a/src/modules/nft_mint_bot/src/config.rs
+++ b/src/modules/nft_mint_bot/src/config.rs
@@ -6,6 +6,7 @@ pub struct Config {
     pub rpc_url: String,
     pub private_key: String,
     pub contract_address: String,
+    pub gas_multiplier: f64,
 }
 
 impl Config {
@@ -15,6 +16,10 @@ impl Config {
             rpc_url: env::var("RPC_URL").expect("RPC_URL not set"),
             private_key: env::var("PRIVATE_KEY").expect("PRIVATE_KEY not set"),
             contract_address: env::var("CONTRACT_ADDRESS").expect("CONTRACT_ADDRESS not set"),
+            gas_multiplier: env::var("GAS_MULTIPLIER")
+                .unwrap_or_else(|_| "1.0".into())
+                .parse()
+                .expect("invalid GAS_MULTIPLIER"),
         }
     }
 }

--- a/src/modules/nft_mint_bot/src/main.rs
+++ b/src/modules/nft_mint_bot/src/main.rs
@@ -1,9 +1,43 @@
 mod config;
+use anyhow::Result;
 use config::Config;
+use ethers::prelude::*;
 use std::env;
 use std::sync::Arc;
-use ethers::prelude::*;
-use anyhow::Result;
+fn apply_multiplier(value: U256, multiplier: f64) -> U256 {
+    let scaled = (value.as_u128() as f64 * multiplier) as u128;
+    U256::from(scaled)
+}
+
+async fn mint_with_provider<P>(
+    provider: Provider<P>,
+    wallet: LocalWallet,
+    cfg: Config,
+    address: Address,
+) -> Result<()>
+where
+    P: JsonRpcClient + 'static,
+{
+    let client = Arc::new(SignerMiddleware::new(provider, wallet));
+
+    let (max_fee, prio_fee) = client.estimate_eip1559_fees(None).await?;
+
+    let contract_addr: Address = cfg.contract_address.parse()?;
+    let mut call = MintContract::new(contract_addr, client.clone()).mint(address);
+
+    if let Some(tx) = call.tx.as_eip1559_mut() {
+        tx.max_fee_per_gas = Some(apply_multiplier(max_fee, cfg.gas_multiplier));
+        tx.max_priority_fee_per_gas = Some(apply_multiplier(prio_fee, cfg.gas_multiplier));
+    }
+
+    let pending = call.send().await?;
+    match pending.await? {
+        Some(receipt) => println!("✅ Minted in tx: {:#x}", receipt.transaction_hash),
+        None => println!("❌ Transaction dropped"),
+    }
+
+    Ok(())
+}
 
 abigen!(
     MintContract,
@@ -18,32 +52,19 @@ abigen!(
 #[tokio::main]
 async fn main() -> Result<()> {
     let cfg = Config::load();
-    let recipient = env::args()
-        .nth(1)
-        .expect("Recipient address required");
+    let recipient = env::args().nth(1).expect("Recipient address required");
     let address: Address = recipient.parse()?;
 
     println!("✅ Config loaded: {}", cfg.rpc_url);
     println!("🚀 Minting to: {}", recipient);
 
     let wallet: LocalWallet = cfg.private_key.parse()?;
-    let client: Arc<dyn Middleware> = if cfg.rpc_url.starts_with("ws") {
+
+    if cfg.rpc_url.starts_with("ws") {
         let provider = Provider::<Ws>::connect(&cfg.rpc_url).await?;
-        Arc::new(SignerMiddleware::new(provider, wallet.clone()))
+        mint_with_provider(provider, wallet, cfg, address).await
     } else {
         let provider = Provider::<Http>::try_from(cfg.rpc_url.as_str())?;
-        Arc::new(SignerMiddleware::new(provider, wallet.clone()))
-    };
-
-    let contract_addr: Address = cfg.contract_address.parse()?;
-    let contract = MintContract::new(contract_addr, client.clone());
-    let call = contract.mint(address);
-    let tx = call.send().await?;
-    match tx.await? {
-        Some(receipt) => println!("✅ Minted in tx: {:#x}", receipt.transaction_hash),
-        None => println!("❌ Transaction dropped"),
+        mint_with_provider(provider, wallet, cfg, address).await
     }
-
-    Ok(())
 }
-

--- a/src/modules/nft_mint_bot/tests/config.rs
+++ b/src/modules/nft_mint_bot/tests/config.rs
@@ -5,9 +5,17 @@ use std::env;
 fn loads_env_vars() {
     env::set_var("RPC_URL", "ws://localhost:8545");
     env::set_var("PRIVATE_KEY", "abc123");
-    env::set_var("CONTRACT_ADDRESS", "0x0000000000000000000000000000000000000000");
+    env::set_var(
+        "CONTRACT_ADDRESS",
+        "0x0000000000000000000000000000000000000000",
+    );
+    env::set_var("GAS_MULTIPLIER", "1.5");
     let cfg = Config::load();
     assert_eq!(cfg.rpc_url, "ws://localhost:8545");
     assert_eq!(cfg.private_key, "abc123");
-    assert_eq!(cfg.contract_address, "0x0000000000000000000000000000000000000000");
+    assert_eq!(
+        cfg.contract_address,
+        "0x0000000000000000000000000000000000000000"
+    );
+    assert_eq!(cfg.gas_multiplier, 1.5);
 }


### PR DESCRIPTION
## Summary
- fetch provider fees when minting NFTs
- allow customizing gas price multiplier via config
- document GAS_MULTIPLIER usage

## Testing
- `cargo test --manifest-path src/modules/nft_mint_bot/Cargo.toml`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6845ec6cadd483309a12a9b5f268d0e0