### PR TITLE
Add gas limit estimation to NFT mint bot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,6 +81,7 @@ PREMIUM_SUBSCRIPTION_PRICE=150
 RPC_URL=wss://eth.llamarpc.com
 PRIVATE_KEY=
 CONTRACT_ADDRESS=
+MINT_GAS_LIMIT= # optional custom gas limit for NFT mints
 ROUTER_ADDRESS=
 WETH_ADDRESS=
 USE_FLASHBOTS=false # enable to submit transactions via Flashbots

--- a/docs/nft_mint_bot.md
+++ b/docs/nft_mint_bot.md
@@ -24,6 +24,12 @@ The bot requires the following variables (see `.env.example`):
 - `RPC_URL` – WebSocket JSON-RPC endpoint used by the Rust bot (e.g. `wss://...`)
 - `PRIVATE_KEY` – private key used to sign transactions
 - `CONTRACT_ADDRESS` – address of the mint contract
+- `MINT_GAS_LIMIT` – **optional** override for the gas limit used when minting
+
+### Tuning Gas Limits
+If your contract has complex logic or you notice `out of gas` errors, increase
+`MINT_GAS_LIMIT`. Leaving it blank will automatically estimate the gas limit
+using your RPC provider.
 
 ## Adding Logic
 Open `src/modules/nft_mint_bot/src/main.rs` and implement your minting logic.

--- a/src/modules/nft_mint_bot/src/config.rs
+++ b/src/modules/nft_mint_bot/src/config.rs
@@ -6,6 +6,7 @@ pub struct Config {
     pub rpc_url: String,
     pub private_key: String,
     pub contract_address: String,
+    pub gas_limit: Option<u64>,
 }
 
 impl Config {
@@ -15,6 +16,7 @@ impl Config {
             rpc_url: env::var("RPC_URL").expect("RPC_URL not set"),
             private_key: env::var("PRIVATE_KEY").expect("PRIVATE_KEY not set"),
             contract_address: env::var("CONTRACT_ADDRESS").expect("CONTRACT_ADDRESS not set"),
+            gas_limit: env::var("MINT_GAS_LIMIT").ok().and_then(|v| v.parse().ok()),
         }
     }
 }

--- a/src/modules/nft_mint_bot/src/gas.rs
+++ b/src/modules/nft_mint_bot/src/gas.rs
@@ -1,0 +1,11 @@
+use anyhow::Result;
+use ethers::prelude::*;
+
+/// Estimate the gas limit for a contract call
+pub async fn estimate_gas_limit<M>(call: ContractCall<M, ()>) -> Result<U256>
+where
+    M: Middleware + 'static,
+{
+    let gas = call.estimate_gas().await?;
+    Ok(gas)
+}

--- a/src/modules/nft_mint_bot/src/lib.rs
+++ b/src/modules/nft_mint_bot/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod config;
+pub mod gas;

--- a/src/modules/nft_mint_bot/src/main.rs
+++ b/src/modules/nft_mint_bot/src/main.rs
@@ -1,9 +1,11 @@
 mod config;
+mod gas;
+use anyhow::Result;
 use config::Config;
+use ethers::prelude::*;
+use gas::estimate_gas_limit;
 use std::env;
 use std::sync::Arc;
-use ethers::prelude::*;
-use anyhow::Result;
 
 abigen!(
     MintContract,
@@ -18,32 +20,46 @@ abigen!(
 #[tokio::main]
 async fn main() -> Result<()> {
     let cfg = Config::load();
-    let recipient = env::args()
-        .nth(1)
-        .expect("Recipient address required");
+    let recipient = env::args().nth(1).expect("Recipient address required");
     let address: Address = recipient.parse()?;
 
     println!("✅ Config loaded: {}", cfg.rpc_url);
     println!("🚀 Minting to: {}", recipient);
 
     let wallet: LocalWallet = cfg.private_key.parse()?;
-    let client: Arc<dyn Middleware> = if cfg.rpc_url.starts_with("ws") {
+    let contract_addr: Address = cfg.contract_address.parse()?;
+
+    if cfg.rpc_url.starts_with("ws") {
         let provider = Provider::<Ws>::connect(&cfg.rpc_url).await?;
-        Arc::new(SignerMiddleware::new(provider, wallet.clone()))
+        let client = Arc::new(SignerMiddleware::new(provider, wallet.clone()));
+        let mut call = MintContract::new(contract_addr, client.clone()).mint(address);
+        let gas_limit = if let Some(limit) = cfg.gas_limit {
+            U256::from(limit)
+        } else {
+            estimate_gas_limit(call.clone()).await?
+        };
+        call = call.gas(gas_limit);
+        let tx = call.send().await?;
+        match tx.await? {
+            Some(receipt) => println!("✅ Minted in tx: {:#x}", receipt.transaction_hash),
+            None => println!("❌ Transaction dropped"),
+        }
     } else {
         let provider = Provider::<Http>::try_from(cfg.rpc_url.as_str())?;
-        Arc::new(SignerMiddleware::new(provider, wallet.clone()))
-    };
-
-    let contract_addr: Address = cfg.contract_address.parse()?;
-    let contract = MintContract::new(contract_addr, client.clone());
-    let call = contract.mint(address);
-    let tx = call.send().await?;
-    match tx.await? {
-        Some(receipt) => println!("✅ Minted in tx: {:#x}", receipt.transaction_hash),
-        None => println!("❌ Transaction dropped"),
+        let client = Arc::new(SignerMiddleware::new(provider, wallet.clone()));
+        let mut call = MintContract::new(contract_addr, client.clone()).mint(address);
+        let gas_limit = if let Some(limit) = cfg.gas_limit {
+            U256::from(limit)
+        } else {
+            estimate_gas_limit(call.clone()).await?
+        };
+        call = call.gas(gas_limit);
+        let tx = call.send().await?;
+        match tx.await? {
+            Some(receipt) => println!("✅ Minted in tx: {:#x}", receipt.transaction_hash),
+            None => println!("❌ Transaction dropped"),
+        }
     }
 
     Ok(())
 }
-

--- a/src/modules/nft_mint_bot/tests/config.rs
+++ b/src/modules/nft_mint_bot/tests/config.rs
@@ -5,9 +5,17 @@ use std::env;
 fn loads_env_vars() {
     env::set_var("RPC_URL", "ws://localhost:8545");
     env::set_var("PRIVATE_KEY", "abc123");
-    env::set_var("CONTRACT_ADDRESS", "0x0000000000000000000000000000000000000000");
+    env::set_var(
+        "CONTRACT_ADDRESS",
+        "0x0000000000000000000000000000000000000000",
+    );
+    env::set_var("MINT_GAS_LIMIT", "123456");
     let cfg = Config::load();
     assert_eq!(cfg.rpc_url, "ws://localhost:8545");
     assert_eq!(cfg.private_key, "abc123");
-    assert_eq!(cfg.contract_address, "0x0000000000000000000000000000000000000000");
+    assert_eq!(
+        cfg.contract_address,
+        "0x0000000000000000000000000000000000000000"
+    );
+    assert_eq!(cfg.gas_limit, Some(123456));
 }


### PR DESCRIPTION
## Summary
- allow optional `MINT_GAS_LIMIT` in env example
- load `MINT_GAS_LIMIT` in NFT mint bot config
- add helper to estimate gas limit for minting transactions
- set gas limit when sending mint transaction
- document how to tune gas limits

## Testing
- `pnpm run test`

------
https://chatgpt.com/codex/tasks/task_e_6845ec71c8708330aba29ef0b06b2024