### PR TITLE
Implement nonce tracking and tx retry

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -22,6 +22,7 @@ export const config = {
   maxQueueSize: parseInt(process.env.MAX_QUEUE_SIZE ?? '1000', 10),
   minBalanceBufferEth: parseFloat(process.env.MIN_BALANCE_BUFFER_ETH ?? '0.1'),
   gasMultiplier: parseFloat(process.env.GAS_MULTIPLIER ?? '1.2'),
+  mintMaxRetries: parseInt(process.env.MINT_MAX_RETRIES ?? '2', 10),
 
   // Twitter API Configuration
   twitterClientId: process.env.TWITTER_CLIENT_ID!,

--- a/src/modules/tx/transaction-engine.ts
+++ b/src/modules/tx/transaction-engine.ts
@@ -4,6 +4,8 @@ import { network } from '@modules/network';
 export interface SendOptions {
   privateTx?: boolean; // send via Flashbots
   gasMultiplier?: number; // apply multiplier to maxFeePerGas
+  nonce?: number;
+  maxRetries?: number;
 }
 
 const FLASHBOTS_RPC = 'https://rpc.flashbots.net';
@@ -27,24 +29,38 @@ export async function sendWithReplacement(
   }
 
   const signer = wallet.connect(provider);
-  const txResponse = await (contract.connect(signer) as any)[functionName](...args, {
-    maxFeePerGas,
-    maxPriorityFeePerGas
-  });
+  const nonce = opts.nonce;
+  const maxRetries = opts.maxRetries ?? 0;
+  const timeout = 30000; // 30 seconds
 
-  let receipt: TransactionReceipt | null = null;
-  try {
-    receipt = await txResponse.wait(1);
-  } catch {
-    // replacement logic: bump gas and resend once
+  let attempt = 0;
+  while (attempt <= maxRetries) {
+    let txResponse;
+    try {
+      txResponse = await (contract.connect(signer) as any)[functionName](...args, {
+        maxFeePerGas,
+        maxPriorityFeePerGas,
+        nonce
+      });
+    } catch (err) {
+      if (attempt >= maxRetries) throw err;
+      console.log(`⏫ Replacing tx nonce ${nonce} (attempt ${attempt + 1})`);
+      maxFeePerGas = maxFeePerGas + maxPriorityFeePerGas;
+      attempt++;
+      continue;
+    }
+
+    const receipt = await provider.waitForTransaction(txResponse.hash, 1, timeout);
+    if (receipt) return receipt;
+
+    attempt++;
+    if (attempt > maxRetries) throw new Error('Transaction timed out');
+
+    console.log(`⏫ Replacing tx nonce ${nonce} (attempt ${attempt})`);
     maxFeePerGas = maxFeePerGas + maxPriorityFeePerGas;
-    const replacement = await (contract.connect(signer) as any)[functionName](...args, {
-      maxFeePerGas,
-      maxPriorityFeePerGas
-    });
-    receipt = await replacement.wait(1);
   }
-  return receipt!;
+
+  throw new Error('Transaction failed');
 }
 
 export function getFlashbotsProvider(): JsonRpcProvider {


### PR DESCRIPTION
## Summary
- track wallet nonce in MintQueue to avoid collisions
- implement retry logic in sendWithReplacement
- expose `mintMaxRetries` in config
- adjust Rust mint bot to compile under ethers v2

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6845ec7b409c83309b75a2a550f5632f