### PR TITLE
Add Flashbots support to mint bot

### DIFF
--- a/docs/nft_mint_bot.md
+++ b/docs/nft_mint_bot.md
@@ -24,6 +24,9 @@ The bot requires the following variables (see `.env.example`):
 - `RPC_URL` – WebSocket JSON-RPC endpoint used by the Rust bot (e.g. `wss://...`)
 - `PRIVATE_KEY` – private key used to sign transactions
 - `CONTRACT_ADDRESS` – address of the mint contract
+- `USE_FLASHBOTS` – when set to `true`, the bot submits transactions through the
+  Flashbots relay at `https://relay.flashbots.net` instead of directly to
+  `RPC_URL`
 
 ## Adding Logic
 Open `src/modules/nft_mint_bot/src/main.rs` and implement your minting logic.

--- a/src/modules/nft_mint_bot/Cargo.lock
+++ b/src/modules/nft_mint_bot/Cargo.lock
@@ -48,6 +48,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,7 +327,13 @@ version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
 ]
 
 [[package]]
@@ -750,7 +771,7 @@ dependencies = [
  "sha2",
  "sha3",
  "thiserror 1.0.69",
- "uuid",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -935,6 +956,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethers-flashbots"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d18fef87b4918a3bec3d7bc08daf0b0b6851b0392eb2329d414269e7cba8adf4"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "ethers",
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "url",
+ "uuid 1.17.0",
+]
+
+[[package]]
 name = "ethers-middleware"
 version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1109,6 +1150,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1462,6 +1518,43 @@ dependencies = [
  "rustls",
  "tokio",
  "tokio-rustls",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1844,6 +1937,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1856,8 +1966,10 @@ dependencies = [
  "anyhow",
  "dotenv",
  "ethers",
+ "ethers-flashbots",
  "serde",
  "tokio",
+ "url",
 ]
 
 [[package]]
@@ -1963,6 +2075,50 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2419,10 +2575,12 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -2434,6 +2592,7 @@ dependencies = [
  "sync_wrapper",
  "system-configuration",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tower-service",
  "url",
@@ -2634,6 +2793,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2673,6 +2841,29 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.9.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3176,6 +3367,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3193,8 +3394,10 @@ checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
 dependencies = [
  "futures-util",
  "log",
+ "native-tls",
  "rustls",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tungstenite",
  "webpki-roots",
@@ -3319,6 +3522,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
+ "native-tls",
  "rand",
  "rustls",
  "sha1",
@@ -3407,6 +3611,22 @@ dependencies = [
  "getrandom 0.2.16",
  "serde",
 ]
+
+[[package]]
+name = "uuid"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -3565,6 +3785,65 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/src/modules/nft_mint_bot/Cargo.toml
+++ b/src/modules/nft_mint_bot/Cargo.toml
@@ -9,3 +9,5 @@ tokio = { version = "1", features = ["full"] }
 dotenv = "0.15"
 serde = { version = "1", features = ["derive"] }
 anyhow = "1"
+ethers-flashbots = "0.15"
+url = "2"

--- a/src/modules/nft_mint_bot/src/config.rs
+++ b/src/modules/nft_mint_bot/src/config.rs
@@ -6,6 +6,7 @@ pub struct Config {
     pub rpc_url: String,
     pub private_key: String,
     pub contract_address: String,
+    pub use_flashbots: bool,
 }
 
 impl Config {
@@ -15,6 +16,10 @@ impl Config {
             rpc_url: env::var("RPC_URL").expect("RPC_URL not set"),
             private_key: env::var("PRIVATE_KEY").expect("PRIVATE_KEY not set"),
             contract_address: env::var("CONTRACT_ADDRESS").expect("CONTRACT_ADDRESS not set"),
+            use_flashbots: env::var("USE_FLASHBOTS")
+                .unwrap_or_else(|_| "false".to_string())
+                .to_lowercase()
+                == "true",
         }
     }
 }

--- a/src/modules/nft_mint_bot/src/main.rs
+++ b/src/modules/nft_mint_bot/src/main.rs
@@ -1,8 +1,10 @@
 mod config;
 use config::Config;
 use std::env;
-use std::sync::Arc;
 use ethers::prelude::*;
+use std::sync::Arc;
+use ethers_flashbots::FlashbotsMiddleware;
+use url::Url;
 use anyhow::Result;
 
 abigen!(
@@ -27,21 +29,61 @@ async fn main() -> Result<()> {
     println!("🚀 Minting to: {}", recipient);
 
     let wallet: LocalWallet = cfg.private_key.parse()?;
-    let client: Arc<dyn Middleware> = if cfg.rpc_url.starts_with("ws") {
-        let provider = Provider::<Ws>::connect(&cfg.rpc_url).await?;
-        Arc::new(SignerMiddleware::new(provider, wallet.clone()))
-    } else {
-        let provider = Provider::<Http>::try_from(cfg.rpc_url.as_str())?;
-        Arc::new(SignerMiddleware::new(provider, wallet.clone()))
-    };
 
     let contract_addr: Address = cfg.contract_address.parse()?;
-    let contract = MintContract::new(contract_addr, client.clone());
-    let call = contract.mint(address);
-    let tx = call.send().await?;
-    match tx.await? {
-        Some(receipt) => println!("✅ Minted in tx: {:#x}", receipt.transaction_hash),
-        None => println!("❌ Transaction dropped"),
+
+    if cfg.use_flashbots {
+        if cfg.rpc_url.starts_with("ws") {
+            let provider = Provider::<Ws>::connect(&cfg.rpc_url).await?;
+            let fb = FlashbotsMiddleware::new(
+                provider,
+                Url::parse("https://relay.flashbots.net")?,
+                wallet.clone(),
+            );
+            let client = Arc::new(SignerMiddleware::new(fb, wallet.clone()));
+            let contract = MintContract::new(contract_addr, client.clone());
+            let call = contract.mint(address);
+            let pending = call.send().await?;
+            match pending.await? {
+                Some(receipt) => println!("✅ Minted in tx: {:#x}", receipt.transaction_hash),
+                None => println!("❌ Transaction dropped"),
+            }
+        } else {
+            let provider = Provider::<Http>::try_from(cfg.rpc_url.as_str())?;
+            let fb = FlashbotsMiddleware::new(
+                provider,
+                Url::parse("https://relay.flashbots.net")?,
+                wallet.clone(),
+            );
+            let client = Arc::new(SignerMiddleware::new(fb, wallet.clone()));
+            let contract = MintContract::new(contract_addr, client.clone());
+            let call = contract.mint(address);
+            let pending = call.send().await?;
+            match pending.await? {
+                Some(receipt) => println!("✅ Minted in tx: {:#x}", receipt.transaction_hash),
+                None => println!("❌ Transaction dropped"),
+            }
+        }
+    } else if cfg.rpc_url.starts_with("ws") {
+        let provider = Provider::<Ws>::connect(&cfg.rpc_url).await?;
+        let client = Arc::new(SignerMiddleware::new(provider, wallet.clone()));
+        let contract = MintContract::new(contract_addr, client.clone());
+        let call = contract.mint(address);
+        let pending = call.send().await?;
+        match pending.await? {
+            Some(receipt) => println!("✅ Minted in tx: {:#x}", receipt.transaction_hash),
+            None => println!("❌ Transaction dropped"),
+        }
+    } else {
+        let provider = Provider::<Http>::try_from(cfg.rpc_url.as_str())?;
+        let client = Arc::new(SignerMiddleware::new(provider, wallet.clone()));
+        let contract = MintContract::new(contract_addr, client.clone());
+        let call = contract.mint(address);
+        let pending = call.send().await?;
+        match pending.await? {
+            Some(receipt) => println!("✅ Minted in tx: {:#x}", receipt.transaction_hash),
+            None => println!("❌ Transaction dropped"),
+        }
     }
 
     Ok(())

--- a/src/modules/nft_mint_bot/tests/config.rs
+++ b/src/modules/nft_mint_bot/tests/config.rs
@@ -6,8 +6,10 @@ fn loads_env_vars() {
     env::set_var("RPC_URL", "ws://localhost:8545");
     env::set_var("PRIVATE_KEY", "abc123");
     env::set_var("CONTRACT_ADDRESS", "0x0000000000000000000000000000000000000000");
+    env::set_var("USE_FLASHBOTS", "true");
     let cfg = Config::load();
     assert_eq!(cfg.rpc_url, "ws://localhost:8545");
     assert_eq!(cfg.private_key, "abc123");
     assert_eq!(cfg.contract_address, "0x0000000000000000000000000000000000000000");
+    assert!(cfg.use_flashbots);
 }


### PR DESCRIPTION
## Summary
- add `use_flashbots` flag to Rust config
- support Flashbots relay in Rust mint bot
- document `USE_FLASHBOTS` variable

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6845ec7e727483308394d0d1ba3e68ae