### PR TITLE
Add Prometheus metrics to NFT mint bot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,7 @@ ENABLE_PERFORMANCE_MONITORING=true
 ALERT_ON_HIGH_FAILURE_RATE=true
 FAILURE_RATE_THRESHOLD=0.15
 METRICS_PORT=9090
+MINT_BOT_METRICS_PORT=9101
 DETECTION_SCORE_THRESHOLD=1 # emit detection opportunities when score >= value
 
 # Payment Integration (if using on-chain payments)

--- a/docs/nft_mint_bot.md
+++ b/docs/nft_mint_bot.md
@@ -24,6 +24,7 @@ The bot requires the following variables (see `.env.example`):
 - `RPC_URL` – WebSocket JSON-RPC endpoint used by the Rust bot (e.g. `wss://...`)
 - `PRIVATE_KEY` – private key used to sign transactions
 - `CONTRACT_ADDRESS` – address of the mint contract
+- `MINT_BOT_METRICS_PORT` – (optional) port for the Prometheus metrics endpoint
 
 ## Adding Logic
 Open `src/modules/nft_mint_bot/src/main.rs` and implement your minting logic.
@@ -34,6 +35,22 @@ contract calls or gas optimisations.
 Multiple users may trigger `/mint-fast` concurrently. Because the bot spawns a
 new process per command, each mint runs isolated and will not block other
 commands. Keep your Rust code efficient to maintain fast response times.
+
+## Metrics
+The bot exposes Prometheus metrics when `MINT_BOT_METRICS_PORT` is set. The
+endpoint is available at `http://localhost:<port>/metrics` and records:
+
+- `tx_latency_seconds` – time from transaction submission to receipt
+- `tx_gas_spent` – gas used for the mint
+- `tx_errors_total` – number of failed mint attempts
+
+Example:
+
+```bash
+cargo run -p nft_mint_bot -- 0xabc...
+# In another terminal
+curl http://localhost:${MINT_BOT_METRICS_PORT:-9101}/metrics
+```
 
 ## Related Commands
 - `/mint-fast` – triggers the mint bot

--- a/src/modules/nft_mint_bot/Cargo.lock
+++ b/src/modules/nft_mint_bot/Cargo.lock
@@ -1856,6 +1856,9 @@ dependencies = [
  "anyhow",
  "dotenv",
  "ethers",
+ "hyper",
+ "once_cell",
+ "prometheus",
  "serde",
  "tokio",
 ]
@@ -2259,6 +2262,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "protobuf",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "proptest"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2273,6 +2291,12 @@ dependencies = [
  "regex-syntax",
  "unarray",
 ]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "quote"

--- a/src/modules/nft_mint_bot/Cargo.toml
+++ b/src/modules/nft_mint_bot/Cargo.toml
@@ -9,3 +9,6 @@ tokio = { version = "1", features = ["full"] }
 dotenv = "0.15"
 serde = { version = "1", features = ["derive"] }
 anyhow = "1"
+hyper = { version = "0.14", features = ["full"] }
+prometheus = "0.13"
+once_cell = "1"

--- a/src/modules/nft_mint_bot/src/lib.rs
+++ b/src/modules/nft_mint_bot/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod config;
+pub mod metrics;

--- a/src/modules/nft_mint_bot/src/main.rs
+++ b/src/modules/nft_mint_bot/src/main.rs
@@ -1,7 +1,10 @@
 mod config;
+mod metrics;
 use config::Config;
+use metrics::METRICS;
 use std::env;
 use std::sync::Arc;
+use std::time::Instant;
 use ethers::prelude::*;
 use anyhow::Result;
 
@@ -18,6 +21,7 @@ abigen!(
 #[tokio::main]
 async fn main() -> Result<()> {
     let cfg = Config::load();
+    metrics::init();
     let recipient = env::args()
         .nth(1)
         .expect("Recipient address required");
@@ -27,21 +31,65 @@ async fn main() -> Result<()> {
     println!("🚀 Minting to: {}", recipient);
 
     let wallet: LocalWallet = cfg.private_key.parse()?;
-    let client: Arc<dyn Middleware> = if cfg.rpc_url.starts_with("ws") {
+
+    if cfg.rpc_url.starts_with("ws") {
         let provider = Provider::<Ws>::connect(&cfg.rpc_url).await?;
-        Arc::new(SignerMiddleware::new(provider, wallet.clone()))
+        let client = Arc::new(SignerMiddleware::new(provider, wallet.clone()));
+        let contract_addr: Address = cfg.contract_address.parse()?;
+        let contract = MintContract::new(contract_addr, client.clone());
+        let call = contract.mint(address);
+        let start = Instant::now();
+        let tx = match call.send().await {
+            Ok(tx) => tx,
+            Err(err) => {
+                METRICS.record_error();
+                return Err(err.into());
+            }
+        };
+        match tx.await {
+            Ok(Some(receipt)) => {
+                let gas = receipt.gas_used.unwrap_or_default().as_u64();
+                METRICS.record_success(start.elapsed().as_secs_f64(), gas);
+                println!("✅ Minted in tx: {:#x}", receipt.transaction_hash);
+            }
+            Ok(None) => {
+                METRICS.record_error();
+                println!("❌ Transaction dropped");
+            }
+            Err(err) => {
+                METRICS.record_error();
+                return Err(err.into());
+            }
+        }
     } else {
         let provider = Provider::<Http>::try_from(cfg.rpc_url.as_str())?;
-        Arc::new(SignerMiddleware::new(provider, wallet.clone()))
-    };
-
-    let contract_addr: Address = cfg.contract_address.parse()?;
-    let contract = MintContract::new(contract_addr, client.clone());
-    let call = contract.mint(address);
-    let tx = call.send().await?;
-    match tx.await? {
-        Some(receipt) => println!("✅ Minted in tx: {:#x}", receipt.transaction_hash),
-        None => println!("❌ Transaction dropped"),
+        let client = Arc::new(SignerMiddleware::new(provider, wallet.clone()));
+        let contract_addr: Address = cfg.contract_address.parse()?;
+        let contract = MintContract::new(contract_addr, client.clone());
+        let call = contract.mint(address);
+        let start = Instant::now();
+        let tx = match call.send().await {
+            Ok(tx) => tx,
+            Err(err) => {
+                METRICS.record_error();
+                return Err(err.into());
+            }
+        };
+        match tx.await {
+            Ok(Some(receipt)) => {
+                let gas = receipt.gas_used.unwrap_or_default().as_u64();
+                METRICS.record_success(start.elapsed().as_secs_f64(), gas);
+                println!("✅ Minted in tx: {:#x}", receipt.transaction_hash);
+            }
+            Ok(None) => {
+                METRICS.record_error();
+                println!("❌ Transaction dropped");
+            }
+            Err(err) => {
+                METRICS.record_error();
+                return Err(err.into());
+            }
+        }
     }
 
     Ok(())

--- a/src/modules/nft_mint_bot/src/metrics.rs
+++ b/src/modules/nft_mint_bot/src/metrics.rs
@@ -1,0 +1,75 @@
+use once_cell::sync::Lazy;
+use prometheus::{Encoder, Histogram, HistogramOpts, IntCounter, Registry, TextEncoder};
+use hyper::{Body, Request, Response, Server};
+use hyper::service::{make_service_fn, service_fn};
+
+pub static METRICS: Lazy<Metrics> = Lazy::new(Metrics::new);
+
+pub struct Metrics {
+    pub registry: Registry,
+    tx_latency: Histogram,
+    gas_spent: Histogram,
+    error_count: IntCounter,
+}
+
+impl Metrics {
+    fn new() -> Self {
+        let registry = Registry::new();
+        let tx_latency = Histogram::with_opts(HistogramOpts::new(
+            "tx_latency_seconds",
+            "Transaction latency in seconds",
+        ))
+        .unwrap();
+        let gas_spent = Histogram::with_opts(HistogramOpts::new(
+            "tx_gas_spent",
+            "Gas used for mint transactions",
+        ))
+        .unwrap();
+        let error_count = IntCounter::new("tx_errors_total", "Total mint errors").unwrap();
+        registry.register(Box::new(tx_latency.clone())).unwrap();
+        registry.register(Box::new(gas_spent.clone())).unwrap();
+        registry.register(Box::new(error_count.clone())).unwrap();
+        Self {
+            registry,
+            tx_latency,
+            gas_spent,
+            error_count,
+        }
+    }
+
+    pub fn record_success(&self, latency: f64, gas: u64) {
+        self.tx_latency.observe(latency);
+        self.gas_spent.observe(gas as f64);
+    }
+
+    pub fn record_error(&self) {
+        self.error_count.inc();
+    }
+}
+
+async fn metrics_handler(_req: Request<Body>) -> Result<Response<Body>, hyper::Error> {
+    let metric_families = METRICS.registry.gather();
+    let mut buffer = Vec::new();
+    let encoder = TextEncoder::new();
+    encoder.encode(&metric_families, &mut buffer).unwrap();
+    Ok(Response::builder()
+        .header("Content-Type", encoder.format_type())
+        .body(Body::from(buffer))
+        .unwrap())
+}
+
+async fn serve_inner(port: u16) {
+    let addr = ([0, 0, 0, 0], port).into();
+    let make_svc = make_service_fn(|_conn| async { Ok::<_, hyper::Error>(service_fn(metrics_handler)) });
+    if let Err(err) = Server::bind(&addr).serve(make_svc).await {
+        eprintln!("Metrics server error: {err}");
+    }
+}
+
+pub fn init() {
+    let port: u16 = std::env::var("MINT_BOT_METRICS_PORT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(9101);
+    tokio::spawn(serve_inner(port));
+}

--- a/src/modules/nft_mint_bot/tests/metrics.rs
+++ b/src/modules/nft_mint_bot/tests/metrics.rs
@@ -1,0 +1,9 @@
+use nft_mint_bot::metrics::METRICS;
+
+#[test]
+fn records_metrics() {
+    METRICS.record_success(0.5, 100);
+    METRICS.record_error();
+    let families = METRICS.registry.gather();
+    assert!(!families.is_empty());
+}


### PR DESCRIPTION
## Summary
- add Prometheus-based metrics collector for the Rust mint bot
- record transaction latency, gas usage and error counts
- expose metrics via `MINT_BOT_METRICS_PORT`
- document metrics usage

## Testing
- `cargo test --manifest-path src/modules/nft_mint_bot/Cargo.toml`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845ec83f7048330875c1283b76f4a40