### PR TITLE
Add batch and signature mint options to NFT mint bot

### DIFF
--- a/src/modules/nft_mint_bot/Cargo.lock
+++ b/src/modules/nft_mint_bot/Cargo.lock
@@ -1856,6 +1856,7 @@ dependencies = [
  "anyhow",
  "dotenv",
  "ethers",
+ "hex",
  "serde",
  "tokio",
 ]

--- a/src/modules/nft_mint_bot/Cargo.toml
+++ b/src/modules/nft_mint_bot/Cargo.toml
@@ -9,3 +9,4 @@ tokio = { version = "1", features = ["full"] }
 dotenv = "0.15"
 serde = { version = "1", features = ["derive"] }
 anyhow = "1"
+hex = "0.4"

--- a/src/modules/nft_mint_bot/src/main.rs
+++ b/src/modules/nft_mint_bot/src/main.rs
@@ -4,11 +4,15 @@ use std::env;
 use std::sync::Arc;
 use ethers::prelude::*;
 use anyhow::Result;
+use ethers::types::Bytes;
+use hex::decode;
 
 abigen!(
     MintContract,
     r#"[
         function mint(address to) external
+        function mintBatch(address[] to, uint256[] amounts) external
+        function mintWithSignature(address to, uint256 amount, bytes signature) external
     ]"#
 );
 
@@ -18,32 +22,94 @@ abigen!(
 #[tokio::main]
 async fn main() -> Result<()> {
     let cfg = Config::load();
-    let recipient = env::args()
-        .nth(1)
-        .expect("Recipient address required");
-    let address: Address = recipient.parse()?;
+    let mut args: Vec<String> = env::args().skip(1).collect();
+
+    // Determine mint mode
+    let mut mode = "mint".to_string();
+    if let Some(first) = args.first() {
+        match first.as_str() {
+            "mint" | "batch" | "signed" => {
+                mode = first.clone();
+                args.remove(0);
+            }
+            _ => {}
+        }
+    }
 
     println!("✅ Config loaded: {}", cfg.rpc_url);
-    println!("🚀 Minting to: {}", recipient);
+    println!("🚀 Mode: {}", mode);
 
     let wallet: LocalWallet = cfg.private_key.parse()?;
-    let client: Arc<dyn Middleware> = if cfg.rpc_url.starts_with("ws") {
+    let contract_addr: Address = cfg.contract_address.parse()?;
+
+    let receipt = if cfg.rpc_url.starts_with("ws") {
         let provider = Provider::<Ws>::connect(&cfg.rpc_url).await?;
-        Arc::new(SignerMiddleware::new(provider, wallet.clone()))
+        let client = Arc::new(SignerMiddleware::new(provider, wallet.clone()));
+        let contract = MintContract::new(contract_addr, client.clone());
+        execute_mint(&mode, &args, contract).await?
     } else {
         let provider = Provider::<Http>::try_from(cfg.rpc_url.as_str())?;
-        Arc::new(SignerMiddleware::new(provider, wallet.clone()))
+        let client = Arc::new(SignerMiddleware::new(provider, wallet.clone()));
+        let contract = MintContract::new(contract_addr, client.clone());
+        execute_mint(&mode, &args, contract).await?
     };
 
-    let contract_addr: Address = cfg.contract_address.parse()?;
-    let contract = MintContract::new(contract_addr, client.clone());
-    let call = contract.mint(address);
-    let tx = call.send().await?;
-    match tx.await? {
-        Some(receipt) => println!("✅ Minted in tx: {:#x}", receipt.transaction_hash),
+    match receipt {
+        Some(r) => println!("✅ Minted in tx: {:#x}", r.transaction_hash),
         None => println!("❌ Transaction dropped"),
     }
 
     Ok(())
+}
+
+async fn execute_mint<M: Middleware + 'static>(
+    mode: &str,
+    args: &[String],
+    contract: MintContract<M>,
+) -> Result<Option<TransactionReceipt>> {
+    let receipt = match mode {
+        "batch" => {
+            let addresses_arg = args.get(0).expect("Recipient addresses required");
+            let amounts_arg = args.get(1).expect("Amounts required");
+            let addresses: Result<Vec<Address>> = addresses_arg
+                .split(',')
+                .map(|a| a.parse().map_err(Into::into))
+                .collect();
+            let amounts: Result<Vec<U256>> = amounts_arg
+                .split(',')
+                .map(|a| U256::from_dec_str(a).map_err(Into::into))
+                .collect();
+            {
+                let call = contract.mint_batch(addresses?, amounts?);
+                let pending = call.send().await?;
+                pending.await?
+            }
+        }
+        "signed" => {
+            let recipient = args.get(0).expect("Recipient address required");
+            let amount = args.get(1).expect("Amount required");
+            let sig = args.get(2).expect("Signature required");
+            let address: Address = recipient.parse()?;
+            let qty = U256::from_dec_str(amount)?;
+            let bytes = decode(sig.trim_start_matches("0x"))?;
+            {
+                let call = contract
+                    .mint_with_signature(address, qty, Bytes::from(bytes));
+                let pending = call.send().await?;
+                pending.await?
+            }
+        }
+        _ => {
+            let recipient = args.get(0).expect("Recipient address required");
+            let address: Address = recipient.parse()?;
+            println!("🚀 Minting to: {}", recipient);
+            {
+                let call = contract.mint(address);
+                let pending = call.send().await?;
+                pending.await?
+            }
+        }
+    };
+    Ok(receipt)
 }
 


### PR DESCRIPTION
## Summary
- extend the `MintContract` ABI with batch and signature mint functions
- add CLI argument parsing to choose mint method and support lists of recipients/amounts
- implement `execute_mint` helper for the different mint modes
- update Cargo dependencies for hex parsing

## Testing
- `cargo test --manifest-path src/modules/nft_mint_bot/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_6845ec848b1c8330be30ca977aa1b3cb