### PR TITLE
Add dynamic guild config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,14 +2,11 @@
 # Discord Configuration
 DISCORD_BOT_TOKEN=your_bot_token_here
 DISCORD_APPLICATION_ID=123456789012345678
-GUILD_ID=your_dao_discord_server_id
-ADMIN_ROLE_IDS=123456789,987654321
-MOD_ROLE_IDS=456789123,789123456
+# Guild settings are now stored dynamically in the database
 
 # Discord bot configuration
 BOT_TOKEN=
 CLIENT_ID=
-GUILD_ID=
 GLOBAL_COMMANDS=false
 WEBHOOK_PORT=5001
 

--- a/docs/client_guide.md
+++ b/docs/client_guide.md
@@ -5,7 +5,7 @@ This guide is aimed at Discord server owners and moderators who want to run the 
 ## Prerequisites
 
 1. Copy `.env.example` to `.env` and fill in the required values. Important variables include:
-   - **Discord**: `DISCORD_BOT_TOKEN`, `DISCORD_APPLICATION_ID`, `GUILD_ID`, `ADMIN_ROLE_IDS`, `MOD_ROLE_IDS`.
+   - **Discord**: `DISCORD_BOT_TOKEN`, `DISCORD_APPLICATION_ID`.
    - **Blockchain/Web3**: `PRIMARY_RPC_URL`, `SECONDARY_RPC_URL`, `TERTIARY_RPC_URL`, `WEBSOCKET_RPC_URL`, `PRIVATE_KEY`, `CONTRACT_ADDRESS`, `CHAIN_ID`.
    - **Database & Cache**: `DATABASE_URL`, `REDIS_URL`.
    - **Monitoring**: `METRICS_PORT`, `ENABLE_PERFORMANCE_MONITORING`.
@@ -39,6 +39,8 @@ The bot provides many slash commands. Some highlights:
 - `/report` – members can report misbehaving users. The bot logs the report, times the user out for ten minutes and notifies moderators.
 - `/ban-user` – ban a user from the server and send them a DM explaining the ban.
 - `/set-modlog` – choose the channel that receives moderation logs.
+- `/set-admin-role` – designate which role has admin privileges for bot commands.
+- `/set-mod-role` – designate the moderator role for bot commands.
 - `/welcome-channel` – set the channel used for join greetings.
 - `/connect-wallet` and `/confirm-wallet` – verify a member's wallet address.
 - `/mint-fast` – invoke the high speed NFT mint bot.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -182,3 +182,12 @@ model TokenCall {
   status        String   // "called" | "deleted" | "executed"
   createdAt     DateTime @default(now())
 }
+
+model GuildConfig {
+  id           String   @id @default(cuid())
+  guildId      String   @unique
+  adminRoleIds String[] @default([])
+  modRoleIds   String[] @default([])
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+}

--- a/src/bot/bot.ts
+++ b/src/bot/bot.ts
@@ -7,6 +7,7 @@ import { blockStreamer } from '@modules/network';
 import { startDetectionWatcher, detectionEvents } from '@modules/detection';
 import { initMetrics } from '@modules/metrics';
 import { globalMintQueue } from '@modules/mint';
+import { prisma } from '@libs/prisma';
 import chalk from 'chalk';
 
 console.log(chalk.cyanBright('🚀 Starting Discord bot...'));
@@ -17,6 +18,15 @@ client.once('ready', async () => {
   await registerCommandHandler(client);
   await registerMessageHandlers(client);
   await deployCommands();
+
+  // Ensure guild configs exist for all current servers
+  for (const guild of client.guilds.cache.values()) {
+    await prisma.guildConfig.upsert({
+      where: { guildId: guild.id },
+      update: {},
+      create: { guildId: guild.id }
+    });
+  }
 
   blockStreamer.start();
   startDetectionWatcher();
@@ -35,5 +45,27 @@ client.once('ready', async () => {
 console.log(chalk.yellowBright('⚠️  Note: Global commands can take up to 1 hour to propagate to all servers!'));
 console.log(chalk.yellowBright('⚠️  Make sure to set the bot token in your .env file!'));
 client.login(config.botToken);
+
+client.on('guildCreate', async guild => {
+  try {
+    await prisma.guildConfig.upsert({
+      where: { guildId: guild.id },
+      update: {},
+      create: { guildId: guild.id }
+    });
+    console.log(chalk.green(`📥 Joined guild: ${guild.name}`));
+  } catch (err) {
+    console.error('Failed to create guild config:', err);
+  }
+});
+
+client.on('guildDelete', async guild => {
+  try {
+    await prisma.guildConfig.delete({ where: { guildId: guild.id } });
+    console.log(chalk.yellow(`📤 Removed from guild: ${guild.id}`));
+  } catch (err) {
+    console.error('Failed to remove guild config:', err);
+  }
+});
 
 console.log(chalk.cyan('🤖 Bot is running...'));

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -5,7 +5,6 @@ export const config = {
   // Discord Bot Configuration
   botToken: process.env.BOT_TOKEN!,
   clientId: process.env.CLIENT_ID!,
-  guildId: process.env.GUILD_ID,
   useGlobalCommands: process.env.GLOBAL_COMMANDS === 'true',
   webhookPort: parseInt(process.env.WEBHOOK_PORT ?? '5001', 10),
   version: '0.0.1',

--- a/src/domains/mods/commands/set-admin-role.ts
+++ b/src/domains/mods/commands/set-admin-role.ts
@@ -1,0 +1,27 @@
+import { SlashCommandBuilder, ChatInputCommandInteraction, PermissionFlagsBits } from 'discord.js';
+import { prisma } from '@libs/prisma';
+
+export const data = new SlashCommandBuilder()
+  .setName('set-admin-role')
+  .setDescription('Assign the admin role for this server')
+  .addRoleOption(opt =>
+    opt.setName('role')
+      .setDescription('Admin role')
+      .setRequired(true)
+  )
+  .setDefaultMemberPermissions(PermissionFlagsBits.Administrator);
+
+export async function execute(interaction: ChatInputCommandInteraction) {
+  const role = interaction.options.getRole('role', true);
+  if (!interaction.guildId) {
+    return interaction.reply({ content: '❌ Must be used in a server.', ephemeral: true });
+  }
+
+  await prisma.guildConfig.upsert({
+    where: { guildId: interaction.guildId },
+    update: { adminRoleIds: { set: [role.id] } },
+    create: { guildId: interaction.guildId, adminRoleIds: [role.id], modRoleIds: [] }
+  });
+
+  await interaction.reply({ content: `✅ Admin role set to <@&${role.id}>`, ephemeral: true });
+}

--- a/src/domains/mods/commands/set-mod-role.ts
+++ b/src/domains/mods/commands/set-mod-role.ts
@@ -1,0 +1,27 @@
+import { SlashCommandBuilder, ChatInputCommandInteraction, PermissionFlagsBits } from 'discord.js';
+import { prisma } from '@libs/prisma';
+
+export const data = new SlashCommandBuilder()
+  .setName('set-mod-role')
+  .setDescription('Assign the moderator role for this server')
+  .addRoleOption(opt =>
+    opt.setName('role')
+      .setDescription('Moderator role')
+      .setRequired(true)
+  )
+  .setDefaultMemberPermissions(PermissionFlagsBits.Administrator);
+
+export async function execute(interaction: ChatInputCommandInteraction) {
+  const role = interaction.options.getRole('role', true);
+  if (!interaction.guildId) {
+    return interaction.reply({ content: '❌ Must be used in a server.', ephemeral: true });
+  }
+
+  await prisma.guildConfig.upsert({
+    where: { guildId: interaction.guildId },
+    update: { modRoleIds: { set: [role.id] } },
+    create: { guildId: interaction.guildId, adminRoleIds: [], modRoleIds: [role.id] }
+  });
+
+  await interaction.reply({ content: `✅ Moderator role set to <@&${role.id}>`, ephemeral: true });
+}


### PR DESCRIPTION
## Summary
- store guild configs in Prisma
- create `/set-admin-role` and `/set-mod-role` commands
- track guild join/leave events
- cleanup env example and docs

## Testing
- `npx --yes prisma generate`
- `pnpm run test`

------
https://chatgpt.com/codex/tasks/task_e_6846b6f1da0c833094ed187235836a95