### PR TITLE
Remove static payment channel configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,9 +68,8 @@ DETECTION_SCORE_THRESHOLD=1 # emit detection opportunities when score >= value
 
 # Payment Integration (if using on-chain payments)
 PAYMENT_TOKEN_ADDRESS=0x...
-PAYMENT_RECEIVER_ADDRESS=0x...
-BASIC_SUBSCRIPTION_PRICE=50
-PREMIUM_SUBSCRIPTION_PRICE=150
+# Comma separated list of wallet addresses to receive payments
+PAYMENT_RECEIVER_ADDRESSES=0x111...,0x222...,0x333...
 
 
 

--- a/README.md
+++ b/README.md
@@ -57,8 +57,10 @@ Advanced gas settings, Flashbots integration and batch minting are documented in
 [`docs/advanced_minting.md`](docs/advanced_minting.md).
 
 ## Command Restrictions & Info
-Commands can be limited to specific channels using `/restrict-command`. Admins
-can view the commands available in the current channel with `/info`.
+Commands can be limited to specific channels using `/restrict-command`. For
+example, run `/restrict-command command:pay channel:#payments` to limit the
+`/pay` command. Admins can view the commands available in the current channel
+with `/info`.
 
 ## Moderation Features
 - `/report` – members can report misbehaving users. The report is logged and the user is timed out for 10 minutes.
@@ -98,6 +100,9 @@ The bot exposes several Discord slash commands:
 - `/connect-wallet` - Link a wallet by signing a message
 - `/wallet-info` - View your connected wallet
 - `/subscription-info` - Check subscription status
+- `/pay` - open a private payment ticket
+- `/confirm-payment` - confirm an on-chain payment
+- `/set-service-price` - admin command to configure service pricing
 - `/projects` - List active mint projects
 - `/mint` - Queue a mint request
 - `/mint-status` - View your last mint status

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,6 +20,7 @@ model User {
   mintAttempts  MintAttempt[]
   walletSessions WalletSession[]
   nftHoldings   NftHolding[]
+  payments      Payment[]
 }
 
 model Subscription {
@@ -190,4 +191,50 @@ model GuildConfig {
   modRoleIds   String[] @default([])
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
+}
+
+model ServicePrice {
+  id        String   @id @default(cuid())
+  name      String   @unique
+  price     String
+  currency  PaymentCurrency
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  payments Payment[]
+}
+
+enum PaymentCurrency {
+  USDT
+  USDC
+  OTHER
+}
+
+enum PaymentStatus {
+  PENDING
+  COMPLETED
+  FAILED
+}
+
+enum PaymentMethod {
+  ON_CHAIN
+  PAYPAL
+  OTHER
+}
+
+model Payment {
+  id           String        @id @default(cuid())
+  userId       String
+  serviceId    String
+  amount       String
+  currency     PaymentCurrency
+  method       PaymentMethod
+  walletAddress String?
+  txHash       String?
+  channelId    String?
+  status       PaymentStatus @default(PENDING)
+  createdAt    DateTime      @default(now())
+
+  user User @relation(fields: [userId], references: [id])
+  service ServicePrice @relation(fields: [serviceId], references: [id])
 }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -39,4 +39,7 @@ export const config = {
 
   // Redis Configuration
   redisUrl: process.env.REDIS_URL || 'redis://localhost:6379',
+
+  // Payment configuration
+  paymentReceiverAddresses: (process.env.PAYMENT_RECEIVER_ADDRESSES ?? '').split(',').map(a => a.trim()).filter(Boolean),
 };

--- a/src/domains/web3/commands/confirm-payment.ts
+++ b/src/domains/web3/commands/confirm-payment.ts
@@ -1,0 +1,51 @@
+import {
+  SlashCommandBuilder,
+  ChatInputCommandInteraction,
+  ChannelType
+} from 'discord.js';
+import { prisma } from '@libs/prisma';
+import { updatePaymentStatus } from '@modules/payment';
+import { network } from '@modules/network';
+import { PaymentStatus } from '@prisma/client';
+
+export const data = new SlashCommandBuilder()
+  .setName('confirm-payment')
+  .setDescription('Confirm your payment by providing a transaction hash')
+  .addStringOption(opt =>
+    opt.setName('txhash')
+      .setDescription('Transaction hash')
+      .setRequired(true)
+  );
+
+export async function execute(interaction: ChatInputCommandInteraction) {
+  const txHash = interaction.options.getString('txhash', true).trim();
+  if (!/^0x([A-Fa-f0-9]{64})$/.test(txHash)) {
+    return interaction.reply({ content: '❌ Invalid transaction hash.', ephemeral: true });
+  }
+
+  const payment = await prisma.payment.findFirst({
+    where: { channelId: interaction.channelId, status: PaymentStatus.PENDING }
+  });
+
+  if (!payment) {
+    return interaction.reply({ content: '❌ Payment not found for this channel.', ephemeral: true });
+  }
+
+  try {
+    await network.withProvider(p => p.waitForTransaction(txHash));
+    const tx = await network.withProvider(p => p.getTransaction(txHash));
+    if (!tx || (payment.walletAddress && tx.to?.toLowerCase() !== payment.walletAddress.toLowerCase())) {
+      return interaction.reply({ content: '❌ Transaction does not match payment.', ephemeral: true });
+    }
+  } catch (err) {
+    console.error(err);
+    return interaction.reply({ content: '❌ Unable to verify transaction.', ephemeral: true });
+  }
+
+  await updatePaymentStatus(payment.id, PaymentStatus.COMPLETED, txHash);
+  await interaction.reply({ content: '✅ Payment confirmed. Closing ticket...', ephemeral: true });
+
+  if (interaction.channel && interaction.channel.type === ChannelType.GuildText) {
+    await interaction.channel.delete().catch(() => {});
+  }
+}

--- a/src/domains/web3/commands/pay.ts
+++ b/src/domains/web3/commands/pay.ts
@@ -1,0 +1,73 @@
+import {
+  SlashCommandBuilder,
+  ChatInputCommandInteraction,
+  ChannelType,
+  PermissionFlagsBits,
+  OverwriteType
+} from 'discord.js';
+import { prisma } from '@libs/prisma';
+import { createPayment } from '@modules/payment';
+import { PaymentCurrency, PaymentMethod } from '@prisma/client';
+
+export const data = new SlashCommandBuilder()
+  .setName('pay')
+  .setDescription('Start a service payment')
+  .addStringOption(opt =>
+    opt.setName('service')
+      .setDescription('Service name')
+      .setRequired(true)
+  )
+  .addStringOption(opt =>
+    opt.setName('currency')
+      .setDescription('Payment currency')
+      .addChoices(
+        { name: 'USDT', value: 'USDT' },
+        { name: 'USDC', value: 'USDC' }
+      )
+      .setRequired(true)
+  );
+
+export const meta = {
+  example: '/pay service:sniper currency:USDT',
+  output: '✅ Payment ticket created'
+};
+
+export async function execute(interaction: ChatInputCommandInteraction) {
+  const serviceName = interaction.options.getString('service', true).toLowerCase();
+  const currency = interaction.options.getString('currency', true) as PaymentCurrency;
+
+  const service = await prisma.servicePrice.findUnique({ where: { name: serviceName } });
+  if (!service) {
+    await interaction.reply({ content: '❌ Unknown service.', ephemeral: true });
+    return;
+  }
+  const amount = service.price;
+
+  let user = await prisma.user.findUnique({ where: { discordId: interaction.user.id } });
+  if (!user) {
+    user = await prisma.user.create({ data: { discordId: interaction.user.id, discordTag: interaction.user.tag } });
+  }
+
+  const payment = await createPayment(user.id, service.id, amount, currency, PaymentMethod.ON_CHAIN);
+
+  if (!interaction.guild) {
+    await interaction.reply({ content: '❌ Must be used inside a server.', ephemeral: true });
+    return;
+  }
+
+  const channel = await interaction.guild.channels.create({
+    name: `payment-${interaction.user.username}-${payment.id.slice(0,4)}`,
+    type: ChannelType.GuildText,
+    permissionOverwrites: [
+      { id: interaction.guild.roles.everyone.id, deny: [PermissionFlagsBits.ViewChannel] },
+      { id: interaction.user.id, allow: [PermissionFlagsBits.ViewChannel] },
+      { id: interaction.guild.ownerId, allow: [PermissionFlagsBits.ViewChannel], type: OverwriteType.Member }
+    ]
+  });
+
+  await prisma.payment.update({ where: { id: payment.id }, data: { channelId: channel.id } });
+
+  await channel.send(`Please send **${amount} ${currency}** to \`${payment.walletAddress}\` for **${service.name}** and then run /confirm-payment txhash:<hash>`);
+
+  await interaction.reply({ content: `✅ Payment ticket created: ${channel}`, ephemeral: true });
+}

--- a/src/domains/web3/commands/set-service-price.ts
+++ b/src/domains/web3/commands/set-service-price.ts
@@ -1,0 +1,38 @@
+import { SlashCommandBuilder, ChatInputCommandInteraction, PermissionFlagsBits } from 'discord.js';
+import { prisma } from '@libs/prisma';
+import { PaymentCurrency } from '@prisma/client';
+
+export const data = new SlashCommandBuilder()
+  .setName('set-service-price')
+  .setDescription('Configure the price for a paid service')
+  .addStringOption(opt =>
+    opt.setName('service')
+      .setDescription('Service name')
+      .setRequired(true)
+  )
+  .addNumberOption(opt =>
+    opt.setName('price')
+      .setDescription('Price amount')
+      .setRequired(true)
+  )
+  .addStringOption(opt =>
+    opt.setName('currency')
+      .setDescription('Payment currency')
+      .addChoices({ name: 'USDT', value: 'USDT' }, { name: 'USDC', value: 'USDC' })
+      .setRequired(true)
+  )
+  .setDefaultMemberPermissions(PermissionFlagsBits.Administrator);
+
+export async function execute(interaction: ChatInputCommandInteraction) {
+  const name = interaction.options.getString('service', true).toLowerCase();
+  const price = interaction.options.getNumber('price', true);
+  const currency = interaction.options.getString('currency', true) as PaymentCurrency;
+
+  await prisma.servicePrice.upsert({
+    where: { name },
+    create: { name, price: String(price), currency },
+    update: { price: String(price), currency }
+  });
+
+  await interaction.reply({ content: `✅ Price for ${name} set to ${price} ${currency}`, ephemeral: true });
+}

--- a/src/modules/payment/index.ts
+++ b/src/modules/payment/index.ts
@@ -1,0 +1,1 @@
+export * from './service';

--- a/src/modules/payment/service.ts
+++ b/src/modules/payment/service.ts
@@ -1,0 +1,47 @@
+import { prisma } from '@libs/prisma';
+import { PaymentCurrency, PaymentStatus, PaymentMethod } from '@prisma/client';
+import { config } from '@config/index';
+
+const receiverAddresses = config.paymentReceiverAddresses;
+
+function selectReceiver(): string | undefined {
+  if (receiverAddresses.length === 0) return undefined;
+  const index = Math.floor(Math.random() * receiverAddresses.length);
+  return receiverAddresses[index];
+}
+
+export async function createPayment(
+  userId: string,
+  serviceId: string,
+  amount: string,
+  currency: PaymentCurrency,
+  method: PaymentMethod,
+  channelId?: string,
+  txHash?: string
+) {
+  const walletAddress = method === PaymentMethod.ON_CHAIN ? selectReceiver() : undefined;
+  return prisma.payment.create({
+    data: {
+      userId,
+      serviceId,
+      amount,
+      currency,
+      method,
+      walletAddress,
+      channelId,
+      txHash,
+      status: PaymentStatus.PENDING,
+    },
+  });
+}
+
+export async function updatePaymentStatus(id: string, status: PaymentStatus, txHash?: string) {
+  return prisma.payment.update({
+    where: { id },
+    data: { status, txHash }
+  });
+}
+
+export async function getUserPayments(userId: string) {
+  return prisma.payment.findMany({ where: { userId } });
+}

--- a/tests/payment.test.ts
+++ b/tests/payment.test.ts
@@ -1,0 +1,33 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { prisma } from '../src/libs/prisma';
+import { PaymentStatus, PaymentCurrency, PaymentMethod } from '@prisma/client';
+
+describe('payment module', () => {
+  it('creates and updates a payment', async () => {
+    const original = prisma.payment as any;
+    const createStub = sinon.stub().resolves({ id: 'pay1' });
+    const updateStub = sinon.stub().resolves({});
+    const findManyStub = sinon.stub().resolves([]);
+    (prisma as any).payment = {
+      create: createStub,
+      update: updateStub,
+      findMany: findManyStub
+    } as any;
+
+    process.env.PAYMENT_RECEIVER_ADDRESSES = '0xabc';
+
+    const { createPayment, updatePaymentStatus, getUserPayments } = await import('../src/modules/payment');
+    await createPayment('u1', 'svc1', '10', PaymentCurrency.USDT, PaymentMethod.ON_CHAIN, 'chan1', 'hash');
+    expect(createStub.calledWithMatch({ data: { userId: 'u1', serviceId: 'svc1', amount: '10', currency: PaymentCurrency.USDT, method: PaymentMethod.ON_CHAIN, walletAddress: sinon.match.string, channelId: 'chan1', txHash: 'hash', status: PaymentStatus.PENDING } })).to.equal(true);
+
+    await updatePaymentStatus('pay1', PaymentStatus.COMPLETED);
+    expect(updateStub.calledWithMatch({ where: { id: 'pay1' }, data: { status: PaymentStatus.COMPLETED } })).to.equal(true);
+
+    await getUserPayments('u1');
+    expect(findManyStub.calledWith({ where: { userId: 'u1' } })).to.equal(true);
+
+    (prisma as any).payment = original;
+  });
+});


### PR DESCRIPTION
## Summary
- allow payment command restrictions to be configured dynamically
- update README with `/restrict-command` usage example
- adjust payment service tests for receiver address

## Testing
- `bash scripts/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6846c235609883309b8b01e3bfa42ea1