### PR TITLE
Enhance confirm-payment verification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,6 +68,9 @@ DETECTION_SCORE_THRESHOLD=1 # emit detection opportunities when score >= value
 
 # Payment Integration (if using on-chain payments)
 PAYMENT_TOKEN_ADDRESS=0x...
+# ERC20 stablecoin contracts
+USDT_ADDRESS=0xdAC17F958D2ee523a2206206994597C13D831ec7
+USDC_ADDRESS=0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606EB48
 # Comma separated list of wallet addresses to receive payments
 PAYMENT_RECEIVER_ADDRESSES=0x111...,0x222...,0x333...
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -42,4 +42,6 @@ export const config = {
 
   // Payment configuration
   paymentReceiverAddresses: (process.env.PAYMENT_RECEIVER_ADDRESSES ?? '').split(',').map(a => a.trim()).filter(Boolean),
+  usdtAddress: process.env.USDT_ADDRESS ?? '',
+  usdcAddress: process.env.USDC_ADDRESS ?? '',
 };

--- a/src/domains/web3/commands/confirm-payment.ts
+++ b/src/domains/web3/commands/confirm-payment.ts
@@ -6,7 +6,9 @@ import {
 import { prisma } from '@libs/prisma';
 import { updatePaymentStatus } from '@modules/payment';
 import { network } from '@modules/network';
-import { PaymentStatus } from '@prisma/client';
+import { PaymentStatus, PaymentCurrency } from '@prisma/client';
+import { config } from '@config/index';
+import { Interface, formatUnits } from 'ethers';
 
 export const data = new SlashCommandBuilder()
   .setName('confirm-payment')
@@ -34,7 +36,32 @@ export async function execute(interaction: ChatInputCommandInteraction) {
   try {
     await network.withProvider(p => p.waitForTransaction(txHash));
     const tx = await network.withProvider(p => p.getTransaction(txHash));
-    if (!tx || (payment.walletAddress && tx.to?.toLowerCase() !== payment.walletAddress.toLowerCase())) {
+    if (!tx) {
+      return interaction.reply({ content: '❌ Unable to fetch transaction.', ephemeral: true });
+    }
+
+    const expectedToken = payment.currency === PaymentCurrency.USDT
+      ? config.usdtAddress.toLowerCase()
+      : payment.currency === PaymentCurrency.USDC
+        ? config.usdcAddress.toLowerCase()
+        : '';
+
+    if (!expectedToken || tx.to?.toLowerCase() !== expectedToken) {
+      return interaction.reply({ content: '❌ Transaction does not match payment.', ephemeral: true });
+    }
+
+    const iface = new Interface(['function transfer(address to, uint256 value)']);
+    let to: string;
+    let value: bigint;
+    try {
+      ({ 0: to, 1: value } = iface.decodeFunctionData('transfer', tx.data));
+    } catch {
+      return interaction.reply({ content: '❌ Invalid transaction data.', ephemeral: true });
+    }
+
+    const amount = formatUnits(value, 6).replace(/\.0+$/, '');
+
+    if (to.toLowerCase() !== payment.walletAddress?.toLowerCase() || amount !== payment.amount) {
       return interaction.reply({ content: '❌ Transaction does not match payment.', ephemeral: true });
     }
   } catch (err) {

--- a/tests/confirmPayment.test.ts
+++ b/tests/confirmPayment.test.ts
@@ -1,0 +1,85 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import sinon from 'sinon';
+process.env.PRIMARY_RPC_URL = 'http://localhost:8545';
+import { prisma } from '../src/libs/prisma';
+import { network } from '../src/modules/network';
+import * as paymentModule from '../src/modules/payment';
+import { ethers } from 'ethers';
+import { PaymentCurrency, PaymentStatus } from '@prisma/client';
+import { ChannelType } from 'discord.js';
+
+function mockInteraction(tx: string) {
+  return {
+    options: { getString: () => tx },
+    channelId: 'chan1',
+    reply: sinon.stub().resolves(),
+    channel: { type: ChannelType.GuildText, delete: sinon.stub().resolves() }
+  } as any;
+}
+
+describe('confirm-payment command', () => {
+  it('confirms payment when transaction matches', async () => {
+    process.env.USDT_ADDRESS = '0xusdt';
+    process.env.USDC_ADDRESS = '0xusdc';
+
+    const wallet = '0x000000000000000000000000000000000000dEaD';
+    const payment = { id: 'pay1', walletAddress: wallet, amount: '10', currency: PaymentCurrency.USDT } as any;
+    const paymentStub = sinon.stub().resolves(payment);
+    const originalPaymentModel = prisma.payment as any;
+    const updateStub = sinon.stub().resolves({});
+    (prisma as any).payment = { findFirst: paymentStub, update: updateStub } as any;
+
+    const iface = new ethers.Interface(['function transfer(address to, uint256 value)']);
+    const data = iface.encodeFunctionData('transfer', [wallet, ethers.parseUnits('10', 6)]);
+    const tx = { to: '0xusdt', data };
+    const provider = {
+      waitForTransaction: sinon.stub().resolves(),
+      getTransaction: sinon.stub().resolves(tx)
+    } as any;
+    const originalWP = network.withProvider;
+    (network as any).withProvider = (fn: any) => fn(provider);
+
+    const { execute } = await import('../src/domains/web3/commands/confirm-payment');
+    const interaction = mockInteraction('0xtx');
+    await execute(interaction);
+
+    expect(updateStub.called).to.equal(true);
+    expect(interaction.reply.calledWithMatch({ content: '✅ Payment confirmed. Closing ticket...', ephemeral: true })).to.equal(true);
+
+    (network as any).withProvider = originalWP;
+    (prisma as any).payment = originalPaymentModel;
+  });
+
+  it('rejects mismatched transaction', async () => {
+    process.env.USDT_ADDRESS = '0xusdt';
+    process.env.USDC_ADDRESS = '0xusdc';
+
+    const wallet = '0x000000000000000000000000000000000000dEaD';
+    const payment = { id: 'pay1', walletAddress: wallet, amount: '10', currency: PaymentCurrency.USDT } as any;
+    const paymentStub = sinon.stub().resolves(payment);
+    const originalPaymentModel = prisma.payment as any;
+    const updateStub = sinon.stub().resolves({});
+    (prisma as any).payment = { findFirst: paymentStub, update: updateStub } as any;
+
+    const iface = new ethers.Interface(['function transfer(address to, uint256 value)']);
+    const data = iface.encodeFunctionData('transfer', [wallet, ethers.parseUnits('5', 6)]); // wrong amount
+    const tx = { to: '0xusdt', data };
+    const provider = {
+      waitForTransaction: sinon.stub().resolves(),
+      getTransaction: sinon.stub().resolves(tx)
+    } as any;
+    const originalWP = network.withProvider;
+    (network as any).withProvider = (fn: any) => fn(provider);
+
+    const { execute } = await import('../src/domains/web3/commands/confirm-payment');
+    const interaction = mockInteraction('0xtx');
+    await execute(interaction);
+
+    expect(updateStub.called).to.equal(false);
+    expect(interaction.reply.calledWithMatch({ content: sinon.match(/^❌/), ephemeral: true })).to.equal(true);
+
+    (network as any).withProvider = originalWP;
+    (prisma as any).payment = originalPaymentModel;
+  });
+});


### PR DESCRIPTION
## Summary
- add USDT/USDC address config
- verify payment details against on-chain tx
- document stablecoin vars
- test matching and mismatched confirmations

## Testing
- `pnpm run test` *(fails: TypeError in confirmPayment.test and other tests)*

------
https://chatgpt.com/codex/tasks/task_e_6846f2211bf88330a3ab7a073056cecb