### PR TITLE
Add payment method management

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,4 +1,5 @@
 import dotenv from 'dotenv';
+import { PaymentMethod } from '@prisma/client';
 dotenv.config();
 
 export const config = {
@@ -44,4 +45,5 @@ export const config = {
   paymentReceiverAddresses: (process.env.PAYMENT_RECEIVER_ADDRESSES ?? '').split(',').map(a => a.trim()).filter(Boolean),
   usdtAddress: process.env.USDT_ADDRESS ?? '',
   usdcAddress: process.env.USDC_ADDRESS ?? '',
+  disabledPaymentMethods: [] as PaymentMethod[],
 };

--- a/src/domains/web3/commands/deactivate-payment-method.ts
+++ b/src/domains/web3/commands/deactivate-payment-method.ts
@@ -1,0 +1,28 @@
+import { SlashCommandBuilder, ChatInputCommandInteraction, PermissionFlagsBits } from 'discord.js';
+import { config } from '@config/index';
+import { PaymentMethod } from '@prisma/client';
+
+export const data = new SlashCommandBuilder()
+  .setName('deactivate-payment-method')
+  .setDescription('Disable a payment method')
+  .addStringOption(opt =>
+    opt.setName('method')
+      .setDescription('Payment method')
+      .setRequired(true)
+      .addChoices(
+        { name: 'ON_CHAIN', value: 'ON_CHAIN' },
+        { name: 'PAYPAL', value: 'PAYPAL' },
+        { name: 'OTHER', value: 'OTHER' }
+      )
+  )
+  .setDefaultMemberPermissions(PermissionFlagsBits.Administrator);
+
+export async function execute(interaction: ChatInputCommandInteraction) {
+  const method = interaction.options.getString('method', true) as PaymentMethod;
+
+  if (!config.disabledPaymentMethods.includes(method)) {
+    config.disabledPaymentMethods.push(method);
+  }
+
+  await interaction.reply({ content: `✅ ${method} disabled for new payments`, ephemeral: true });
+}

--- a/src/modules/payment/service.ts
+++ b/src/modules/payment/service.ts
@@ -11,6 +11,10 @@ import { config } from '@config/index';
 
 const receiverAddresses = config.paymentReceiverAddresses;
 
+function methodEnabled(method: PaymentMethod): boolean {
+  return !config.disabledPaymentMethods.includes(method);
+}
+
 function selectReceiver(): string | undefined {
   if (receiverAddresses.length === 0) return undefined;
   const index = Math.floor(Math.random() * receiverAddresses.length);
@@ -26,6 +30,9 @@ export async function createPayment(
   channelId?: string,
   txHash?: string
 ) {
+  if (!methodEnabled(method)) {
+    throw new Error('Payment method disabled');
+  }
   const walletAddress =
     method === PaymentMethod.ON_CHAIN ? selectReceiver() : undefined;
 

--- a/tests/access.test.ts
+++ b/tests/access.test.ts
@@ -1,0 +1,27 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { prisma } from '../src/libs/prisma';
+import { checkUserAccess, AccessLevel } from '../src/modules/mint/access';
+
+describe('subscription expiry check', () => {
+  it('marks expired subscriptions inactive', async () => {
+    const findUser = sinon.stub().resolves({ id: 'u1' });
+    const findSub = sinon.stub().resolves({ id: 's1', userId: 'u1', subscriptionType: 'BASIC', isActive: true, expiresAt: new Date(Date.now() - 1000) });
+    const updateSub = sinon.stub().resolves({});
+    const originalUser = prisma.user;
+    const originalSub = prisma.subscription;
+    const originalHolding = prisma.nftHolding;
+    (prisma as any).user = { findUnique: findUser } as any;
+    (prisma as any).subscription = { findFirst: findSub, update: updateSub } as any;
+    (prisma as any).nftHolding = { findFirst: sinon.stub().resolves(null) } as any;
+
+    const level = await checkUserAccess('discord');
+    expect(level).to.equal(AccessLevel.NONE);
+    expect(updateSub.calledWithMatch({ where: { id: 's1' }, data: { isActive: false } })).to.equal(true);
+
+    (prisma as any).user = originalUser;
+    (prisma as any).subscription = originalSub;
+    (prisma as any).nftHolding = originalHolding;
+  });
+});

--- a/tests/payCommands.test.ts
+++ b/tests/payCommands.test.ts
@@ -1,3 +1,4 @@
+process.env.DATABASE_URL = 'postgresql://user:pass@localhost:5432/db';
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import sinon from 'sinon';
@@ -5,11 +6,10 @@ import { ChannelType } from 'discord.js';
 import { prisma } from '../src/libs/prisma';
 import { cache } from '../src/lib/cache';
 import { PaymentStatus } from '@prisma/client';
+import { ethers } from 'ethers';
 
-import { execute as setServicePrice } from '../src/domains/web3/commands/set-service-price';
-import { execute as pay } from '../src/domains/web3/commands/pay';
-import { execute as confirmPayment } from '../src/domains/web3/commands/confirm-payment';
 import { execute as restrictCommand } from '../src/domains/core/commands/restrict-command';
+// other command modules are imported dynamically within tests
 import { network } from '../src/modules/network';
 
 function mockInteraction(opts: any) {
@@ -33,25 +33,39 @@ describe('payment command flow', () => {
     const original = prisma.servicePrice;
     (prisma as any).servicePrice = { upsert } as any;
     const interaction = mockInteraction({ service: 'sniper', price: 5, currency: 'USDT' });
-    await setServicePrice(interaction as any);
+    const { execute } = await import('../src/domains/web3/commands/set-service-price');
+    await execute(interaction as any);
     expect(upsert.calledWithMatch({ where: { name: 'sniper' }, create: { name: 'sniper', price: '5', currency: 'USDT' }, update: { price: '5', currency: 'USDT' } })).to.equal(true);
     (prisma as any).servicePrice = original;
   });
 
   it('creates a ticket with /pay and cleans up on /confirm-payment', async () => {
-    process.env.PAYMENT_RECEIVER_ADDRESSES = '0xwallet';
+    process.env.PAYMENT_RECEIVER_ADDRESSES = '0x000000000000000000000000000000000000dEaD';
+    process.env.USDT_ADDRESS = '0xusdt';
+    process.env.USDC_ADDRESS = '0xusdc';
+    process.env.DATABASE_URL = 'postgresql://user:pass@localhost:5432/db';
+    Object.keys(require.cache).forEach(k => {
+      if (k.includes('src/config/index')) delete (require as any).cache[k];
+      if (k.includes('src/modules/payment')) delete (require as any).cache[k];
+    });
 
     const svcStub = sinon.stub().resolves({ id: 'svc1', name: 'sniper', price: '10' });
     const originalService = prisma.servicePrice;
     (prisma as any).servicePrice = { findUnique: svcStub } as any;
+
+    const originalCfg = prisma.guildConfig;
+    (prisma as any).guildConfig = { findUnique: sinon.stub().resolves({ adminRoleIds: [] }) } as any;
 
     const userFind = sinon.stub().resolves(null);
     const userCreate = sinon.stub().resolves({ id: 'uid1' });
     const originalUser = prisma.user;
     (prisma as any).user = { findUnique: userFind, create: userCreate } as any;
 
-    const payCreate = sinon.stub().resolves({ id: 'pay1', walletAddress: '0xwallet' });
-    const payUpdate = sinon.stub().resolves();
+    const payCreate = sinon.stub().resolves({ id: 'pay1', walletAddress: '0x000000000000000000000000000000000000dEaD' });
+    const payUpdate = sinon.stub().resolves({ service: { name: 'subscription-basic' } });
+    const subCreate = sinon.stub().resolves();
+    const originalSub = prisma.subscription;
+    (prisma as any).subscription = { create: subCreate } as any;
     const originalPayment = prisma.payment;
     (prisma as any).payment = { create: payCreate, update: payUpdate, findFirst: sinon.stub() } as any;
 
@@ -61,21 +75,28 @@ describe('payment command flow', () => {
     const guild = { channels: { create: createChannel }, roles: { everyone: { id: 'everyone' } }, ownerId: 'owner' };
     const interaction = mockInteraction({ service: 'sniper', currency: 'USDT', guild });
 
+    const { execute: pay } = await import('../src/domains/web3/commands/pay');
     await pay(interaction as any);
     expect(createChannel.called).to.equal(true);
     expect(sendStub.called).to.equal(true);
     expect(payUpdate.calledWithMatch({ where: { id: 'pay1' }, data: { channelId: 'chan1' } })).to.equal(true);
 
-    (prisma as any).payment.findFirst = sinon.stub().resolves({ id: 'pay1', walletAddress: '0xwallet' });
+    (prisma as any).payment.findFirst = sinon.stub().resolves({ id: 'pay1', walletAddress: '0x000000000000000000000000000000000000dEaD', amount: '10', currency: 'USDT' });
     const deleteStub = sinon.stub().resolves();
     interaction.channel = { id: 'chan1', type: ChannelType.GuildText, delete: deleteStub } as any;
     interaction.channelId = 'chan1';
     (interaction.options.getString as any) = () => '0x' + 'a'.repeat(64);
 
-    const netStub = sinon.stub(network, 'withProvider');
-    netStub.onFirstCall().resolves({});
-    netStub.onSecondCall().resolves({ to: '0xwallet' });
+    const iface = new ethers.Interface(['function transfer(address to, uint256 value)']);
+    const data = iface.encodeFunctionData('transfer', ['0x000000000000000000000000000000000000dEaD', ethers.parseUnits('10', 6)]);
+    const tx = { to: '0xusdt', data } as any;
+    const provider = {
+      waitForTransaction: sinon.stub().resolves(),
+      getTransaction: sinon.stub().resolves(tx)
+    } as any;
+    const netStub = sinon.stub(network, 'withProvider').callsFake(fn => fn(provider));
 
+    const { execute: confirmPayment } = await import('../src/domains/web3/commands/confirm-payment');
     await confirmPayment(interaction as any);
     expect(deleteStub.called).to.equal(true);
     expect(payUpdate.calledWithMatch({ where: { id: 'pay1' }, data: { status: PaymentStatus.COMPLETED, txHash: sinon.match.string } })).to.equal(true);
@@ -84,6 +105,8 @@ describe('payment command flow', () => {
     (prisma as any).servicePrice = originalService;
     (prisma as any).user = originalUser;
     (prisma as any).payment = originalPayment;
+    (prisma as any).guildConfig = originalCfg;
+    (prisma as any).subscription = originalSub;
   });
 
   it('honors command restriction set by /restrict-command', async () => {
@@ -110,7 +133,28 @@ describe('payment command flow', () => {
     const createChannel = sinon.stub().resolves({ id: 'c1', send: sinon.stub().resolves() });
     guild.channels.create = createChannel;
 
-    await pay(payInteraction as any);
+    const originalCfg2 = prisma.guildConfig;
+    (prisma as any).guildConfig = { findUnique: sinon.stub().resolves({ adminRoleIds: [] }) } as any;
+
+    process.env.PAYMENT_RECEIVER_ADDRESSES = '0x000000000000000000000000000000000000dEaD';
+    process.env.USDT_ADDRESS = '0xusdt';
+    process.env.USDC_ADDRESS = '0xusdc';
+    process.env.DATABASE_URL = 'postgresql://user:pass@localhost:5432/db';
+    Object.keys(require.cache).forEach(k => {
+      if (k.includes('src/config/index')) delete (require as any).cache[k];
+      if (k.includes('src/modules/payment')) delete (require as any).cache[k];
+    });
+    const { execute: payCmd } = await import('../src/domains/web3/commands/pay');
+    await payCmd(payInteraction as any);
     expect(createChannel.called).to.equal(true);
+    (prisma as any).guildConfig = originalCfg2;
+  });
+
+  it('disables payment method via command', async () => {
+    const interaction = mockInteraction({ method: 'ON_CHAIN', guild: { id: 'g' } });
+    const { execute } = await import('../src/domains/web3/commands/deactivate-payment-method');
+    await execute(interaction as any);
+    const { config } = await import('../src/config');
+    expect(config.disabledPaymentMethods.includes('ON_CHAIN' as any)).to.equal(true);
   });
 });


### PR DESCRIPTION
## Summary
- allow disabling payment methods via config
- expose `/deactivate-payment-method` command
- include admin roles in payment ticket channels
- deactivate expired subscriptions when checking access
- adjust tests for new flow

## Testing
- `pnpm run test` *(fails: Prisma environment variable not found)*

------
https://chatgpt.com/codex/tasks/task_e_68472bd7d35c8330a14ddb240e9b72b3