### PR TITLE
Add CLI-driven NFT mint bot

### DIFF
--- a/src/modules/nft_mint_bot/Cargo.lock
+++ b/src/modules/nft_mint_bot/Cargo.lock
@@ -63,6 +63,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,6 +397,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+
+[[package]]
 name = "coins-bip32"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,6 +487,12 @@ dependencies = [
  "sha3",
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "const-hex"
@@ -1762,6 +1858,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1983,6 +2085,7 @@ name = "nft_mint_bot"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "dotenv",
  "ethers",
  "ethers-flashbots",
@@ -1991,6 +2094,7 @@ dependencies = [
  "once_cell",
  "prometheus",
  "serde",
+ "serde_json",
  "serial_test",
  "tokio",
  "url",
@@ -2075,6 +2179,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "open-fastrlp"
@@ -3165,6 +3275,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3671,6 +3787,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/src/modules/nft_mint_bot/Cargo.toml
+++ b/src/modules/nft_mint_bot/Cargo.toml
@@ -15,6 +15,8 @@ hyper = { version = "0.14", features = ["full"] }
 prometheus = "0.13"
 once_cell = "1"
 hex = "0.4"
+clap = { version = "4", features = ["derive"] }
+serde_json = "1"
 
 [dev-dependencies]
 serial_test = "2"

--- a/src/modules/nft_mint_bot/src/config.rs
+++ b/src/modules/nft_mint_bot/src/config.rs
@@ -5,7 +5,7 @@ use std::env;
 pub struct Config {
     pub rpc_urls: Vec<String>,
     pub private_key: String,
-    pub contract_address: String,
+    pub contract_address: Option<String>,
     pub use_flashbots: bool,
     pub gas_limit: Option<u64>,
     pub gas_multiplier: f64,
@@ -44,7 +44,7 @@ impl Config {
         Self {
             rpc_urls,
             private_key: env::var("PRIVATE_KEY").expect("PRIVATE_KEY not set"),
-            contract_address: env::var("CONTRACT_ADDRESS").expect("CONTRACT_ADDRESS not set"),
+            contract_address: env::var("CONTRACT_ADDRESS").ok(),
             use_flashbots: env::var("USE_FLASHBOTS")
                 .unwrap_or_else(|_| "false".to_string())
                 .to_lowercase()

--- a/src/modules/nft_mint_bot/src/main.rs
+++ b/src/modules/nft_mint_bot/src/main.rs
@@ -3,65 +3,108 @@ mod gas;
 mod metrics;
 mod provider_pool;
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
+use clap::{Parser, ValueEnum};
 use config::Config;
+use ethers::abi::{Abi, AbiParser};
 use ethers::prelude::*;
 use gas::estimate_gas_limit;
 use hex::decode;
 use metrics::METRICS;
 use provider_pool::ProviderPool;
-use std::env;
-use ethers_flashbots::FlashbotsMiddleware;
-use url::Url;
+use std::fs;
 use std::sync::Arc;
 use std::time::Instant;
+use ethers_flashbots::FlashbotsMiddleware;
+use url::Url;
 
+/// Apply a multiplier to a gas value
 fn apply_multiplier(value: U256, multiplier: f64) -> U256 {
     let scaled = (value.as_u128() as f64 * multiplier) as u128;
     U256::from(scaled)
 }
 
-abigen!(
-    MintContract,
-    r#"[
-        function mint(address to) external
-        function mintBatch(address[] to, uint256[] amounts) external
-        function mintWithSignature(address to, uint256 amount, bytes signature) external
-    ]"#
-);
+const DEFAULT_ABI: &str = r#"[
+    function mint(address to) external,
+    function mintBatch(address[] to, uint256[] amounts) external,
+    function mintWithSignature(address to, uint256 amount, bytes signature) external
+]"#;
+
+#[derive(Clone, Debug, ValueEnum)]
+enum Mode {
+    Mint,
+    Batch,
+    Signed,
+}
+
+/// Command line arguments
+#[derive(Parser, Debug)]
+#[command(author, version, about)]
+struct Cli {
+    /// Target contract address
+    #[arg(long)]
+    contract: Option<String>,
+    /// Minting mode
+    #[arg(long, value_enum, default_value_t = Mode::Mint)]
+    mode: Mode,
+    /// Recipient address or comma separated list (for batch)
+    #[arg(long)]
+    to: Option<String>,
+    /// Amount for signed mints or comma list for batch
+    #[arg(long)]
+    amount: Option<String>,
+    /// Signature for signed mint
+    #[arg(long)]
+    signature: Option<String>,
+    /// Path to ABI JSON file
+    #[arg(long)]
+    abi: Option<String>,
+    /// Override mint function name (mint mode only)
+    #[arg(long)]
+    mint_function: Option<String>,
+    /// Override gas limit
+    #[arg(long)]
+    gas_limit: Option<u64>,
+    /// ETH value to send with tx
+    #[arg(long)]
+    value: Option<String>,
+    /// Legacy positional recipient
+    recipient: Option<String>,
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
     metrics::init();
     let cfg = Config::load();
-    let mut args: Vec<String> = env::args().skip(1).collect();
-
-    // Determine mint mode
-    let mut mode = "mint".to_string();
-    if let Some(first) = args.first() {
-        match first.as_str() {
-            "mint" | "batch" | "signed" => {
-                mode = first.clone();
-                args.remove(0);
-            }
-            _ => {}
-        }
-    }
+    let cli = Cli::parse();
 
     println!("✅ Loaded {} RPC URL(s)", cfg.rpc_urls.len());
-    println!("🚀 Mode: {}", mode);
+    println!("🚀 Mode: {:?}", cli.mode);
     if cfg.use_flashbots {
         println!("⚡ Flashbots enabled");
     }
 
     let wallet: LocalWallet = cfg.private_key.parse()?;
-    let contract_addr: Address = cfg.contract_address.parse()?;
+    let contract_addr_str = cli
+        .contract
+        .clone()
+        .or_else(|| cfg.contract_address.clone())
+        .ok_or_else(|| anyhow!("Contract address must be provided"))?;
+    let contract_addr: Address = contract_addr_str.parse()?;
+
+    let abi: Abi = if let Some(path) = cli.abi.as_deref() {
+        let data = fs::read_to_string(path)?;
+        serde_json::from_str(&data)?
+    } else {
+        AbiParser::default().parse_str(DEFAULT_ABI)?
+    };
 
     let mut last_err: Option<anyhow::Error> = None;
     for url in &cfg.rpc_urls {
         println!("🔗 Trying provider: {}", url);
-
-        match try_provider(url, &wallet, contract_addr, &mode, &args, &cfg).await {
+        match try_provider(url, &wallet, contract_addr, &cli, &cfg, abi.clone())
+            .await
+        {
             Ok(Some(receipt)) => {
                 let gas = receipt.gas_used.unwrap_or_default().as_u64();
                 METRICS.record_success(Instant::now().elapsed().as_secs_f64(), gas);
@@ -81,73 +124,71 @@ async fn main() -> Result<()> {
         }
     }
 
-    Err(last_err.unwrap_or_else(|| anyhow::anyhow!("All RPC providers failed")))
+    Err(last_err.unwrap_or_else(|| anyhow!("All RPC providers failed")))
 }
 
 async fn try_provider(
     url: &str,
     wallet: &LocalWallet,
     contract_addr: Address,
-    mode: &str,
-    args: &[String],
+    cli: &Cli,
     cfg: &Config,
+    abi: Abi,
 ) -> Result<Option<TransactionReceipt>> {
-    let _start = Instant::now();
-
     if cfg.use_flashbots {
-        // Use Flashbots middleware
         if url.starts_with("ws") {
             let provider = Provider::<Ws>::connect(url).await?;
-            let fb = FlashbotsMiddleware::new(
-                provider,
-                Url::parse("https://relay.flashbots.net")?,
-                wallet.clone(),
-            );
+            let fb = FlashbotsMiddleware::new(provider, Url::parse("https://relay.flashbots.net")?, wallet.clone());
             let client = Arc::new(SignerMiddleware::new(fb, wallet.clone()));
-            let contract = MintContract::new(contract_addr, client);
-            execute_mint(mode, args, contract, cfg).await
+            let contract = Contract::new(contract_addr, abi, client);
+            execute_mint(cli, contract, cfg).await
         } else {
             let provider = Provider::<Http>::try_from(url)?;
-            let fb = FlashbotsMiddleware::new(
-                provider,
-                Url::parse("https://relay.flashbots.net")?,
-                wallet.clone(),
-            );
+            let fb = FlashbotsMiddleware::new(provider, Url::parse("https://relay.flashbots.net")?, wallet.clone());
             let client = Arc::new(SignerMiddleware::new(fb, wallet.clone()));
-            let contract = MintContract::new(contract_addr, client);
-            execute_mint(mode, args, contract, cfg).await
+            let contract = Contract::new(contract_addr, abi, client);
+            execute_mint(cli, contract, cfg).await
+        }
+    } else if url.starts_with("ws") {
+        match ProviderPool::new(url.to_string(), 3).await {
+            Ok(pool) => {
+                let provider = pool.get_provider().await;
+                let client = Arc::new(SignerMiddleware::new(provider, wallet.clone()));
+                let contract = Contract::new(contract_addr, abi, client);
+                execute_mint(cli, contract, cfg).await
+            }
+            Err(e) => Err(e.into()),
         }
     } else {
-        // Use regular providers
-        if url.starts_with("ws") {
-            match ProviderPool::new(url.to_string(), 3).await {
-                Ok(pool) => {
-                    let provider = pool.get_provider().await;
-                    let client = Arc::new(SignerMiddleware::new(provider, wallet.clone()));
-                    let contract = MintContract::new(contract_addr, client);
-                    execute_mint(mode, args, contract, cfg).await
-                }
-                Err(e) => Err(e.into()),
-            }
-        } else {
-            let provider = Provider::<Http>::try_from(url)?;
-            let client = Arc::new(SignerMiddleware::new(provider, wallet.clone()));
-            let contract = MintContract::new(contract_addr, client);
-            execute_mint(mode, args, contract, cfg).await
-        }
+        let provider = Provider::<Http>::try_from(url)?;
+        let client = Arc::new(SignerMiddleware::new(provider, wallet.clone()));
+        let contract = Contract::new(contract_addr, abi, client);
+        execute_mint(cli, contract, cfg).await
     }
 }
 
 async fn execute_mint<M: Middleware + 'static>(
-    mode: &str,
-    args: &[String],
-    contract: MintContract<M>,
+    cli: &Cli,
+    contract: Contract<M>,
     cfg: &Config,
 ) -> Result<Option<TransactionReceipt>> {
-    match mode {
-        "batch" => {
-            let addresses_arg = args.get(0).expect("Recipient addresses required");
-            let amounts_arg = args.get(1).expect("Amounts required");
+    let func = cli.mint_function.clone().unwrap_or_else(|| match cli.mode {
+        Mode::Mint => "mint".to_string(),
+        Mode::Batch => "mintBatch".to_string(),
+        Mode::Signed => "mintWithSignature".to_string(),
+    });
+
+    match cli.mode {
+        Mode::Batch => {
+            let addresses_arg = cli
+                .to
+                .as_deref()
+                .or(cli.recipient.as_deref())
+                .ok_or_else(|| anyhow!("Recipient addresses required"))?;
+            let amounts_arg = cli
+                .amount
+                .as_deref()
+                .ok_or_else(|| anyhow!("Amounts required"))?;
 
             let addresses: Result<Vec<Address>> = addresses_arg
                 .split(',')
@@ -158,34 +199,45 @@ async fn execute_mint<M: Middleware + 'static>(
                 .map(|a| U256::from_dec_str(a).map_err(Into::into))
                 .collect();
 
-            let mut call = contract.mint_batch(addresses?, amounts?);
-            call = call_with_gas(call, contract.client().clone(), cfg).await?;
+            let mut call = contract.method::<_, ()>(&func, (addresses?, amounts?))?;
+            call = call_with_gas(call, contract.client().clone(), cfg, cli).await?;
             let pending = call.send().await?;
             Ok(pending.await?)
         }
-
-        "signed" => {
-            let recipient = args.get(0).expect("Recipient address required");
-            let amount = args.get(1).expect("Amount required");
-            let sig = args.get(2).expect("Signature required");
-
+        Mode::Signed => {
+            let recipient = cli
+                .to
+                .as_deref()
+                .or(cli.recipient.as_deref())
+                .ok_or_else(|| anyhow!("Recipient address required"))?;
+            let amount = cli
+                .amount
+                .as_deref()
+                .ok_or_else(|| anyhow!("Amount required"))?;
+            let sig = cli
+                .signature
+                .as_deref()
+                .ok_or_else(|| anyhow!("Signature required"))?;
             let address: Address = recipient.parse()?;
             let qty = U256::from_dec_str(amount)?;
             let bytes = decode(sig.trim_start_matches("0x"))?;
 
-            let mut call = contract.mint_with_signature(address, qty, Bytes::from(bytes));
-            call = call_with_gas(call, contract.client().clone(), cfg).await?;
+            let mut call = contract.method::<_, ()>(&func, (address, qty, Bytes::from(bytes)))?;
+            call = call_with_gas(call, contract.client().clone(), cfg, cli).await?;
             let pending = call.send().await?;
             Ok(pending.await?)
         }
-
-        _ => {
-            let recipient = args.get(0).expect("Recipient address required");
+        Mode::Mint => {
+            let recipient = cli
+                .to
+                .as_deref()
+                .or(cli.recipient.as_deref())
+                .ok_or_else(|| anyhow!("Recipient address required"))?;
             let address: Address = recipient.parse()?;
             println!("🚀 Minting to: {}", recipient);
 
-            let mut call = contract.mint(address);
-            call = call_with_gas(call, contract.client().clone(), cfg).await?;
+            let mut call = contract.method::<_, ()>(&func, address)?;
+            call = call_with_gas(call, contract.client().clone(), cfg, cli).await?;
             let pending = call.send().await?;
             Ok(pending.await?)
         }
@@ -196,18 +248,25 @@ async fn call_with_gas<M: Middleware + 'static>(
     mut call: ContractCall<M, ()>,
     client: Arc<M>,
     cfg: &Config,
+    cli: &Cli,
 ) -> Result<ContractCall<M, ()>> {
-    let gas_limit = if let Some(limit) = cfg.gas_limit {
+    let gas_limit = if let Some(limit) = cli.gas_limit.or(cfg.gas_limit) {
         U256::from(limit)
     } else {
         estimate_gas_limit(call.clone()).await?
     };
     call = call.gas(gas_limit);
 
+    if let Some(val) = &cli.value {
+        let value = U256::from_dec_str(val)?;
+        call = call.value(value);
+    }
+
     if let Some(tx) = call.tx.as_eip1559_mut() {
         let (max_fee, prio_fee) = client.estimate_eip1559_fees(None).await?;
         tx.max_fee_per_gas = Some(apply_multiplier(max_fee, cfg.gas_multiplier));
-        tx.max_priority_fee_per_gas = Some(apply_multiplier(prio_fee, cfg.gas_multiplier));
+        tx.max_priority_fee_per_gas =
+            Some(apply_multiplier(prio_fee, cfg.gas_multiplier));
     }
 
     Ok(call)

--- a/src/modules/nft_mint_bot/tests/config.rs
+++ b/src/modules/nft_mint_bot/tests/config.rs
@@ -17,8 +17,8 @@ fn loads_env_vars() {
     assert_eq!(cfg.rpc_urls, vec!["ws://localhost:8545".to_string()]);
     assert_eq!(cfg.private_key, "abc123");
     assert_eq!(
-        cfg.contract_address,
-        "0x0000000000000000000000000000000000000000"
+        cfg.contract_address.as_deref(),
+        Some("0x0000000000000000000000000000000000000000")
     );
     assert!(cfg.use_flashbots);
     assert_eq!(cfg.gas_limit, Some(123456));
@@ -43,8 +43,8 @@ fn loads_env_vars_without_flashbots() {
     assert_eq!(cfg.rpc_urls, vec!["http://localhost:8545".to_string()]);
     assert_eq!(cfg.private_key, "def456");
     assert_eq!(
-        cfg.contract_address,
-        "0x1111111111111111111111111111111111111111"
+        cfg.contract_address.as_deref(),
+        Some("0x1111111111111111111111111111111111111111")
     );
     assert!(!cfg.use_flashbots); // Should default to false
     assert_eq!(cfg.gas_limit, Some(654321));
@@ -73,8 +73,8 @@ fn loads_multiple_rpc_urls() {
     ]);
     assert_eq!(cfg.private_key, "ghi789");
     assert_eq!(
-        cfg.contract_address,
-        "0x2222222222222222222222222222222222222222"
+        cfg.contract_address.as_deref(),
+        Some("0x2222222222222222222222222222222222222222")
     );
     assert!(!cfg.use_flashbots);
 


### PR DESCRIPTION
## Summary
- allow specifying contract, mode, and arguments via clap
- load optional ABI files at runtime
- make CONTRACT_ADDRESS optional in config
- update tests for new config behaviour

## Testing
- `cargo test --manifest-path src/modules/nft_mint_bot/Cargo.toml`
- `bash scripts/run-tests.sh` *(fails: DATABASE_URL not set)*

------
https://chatgpt.com/codex/tasks/task_e_684e80ba27648330940afeffee846636