### PR TITLE
Add multi-chain ABI fetch support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,8 @@ ROUTER_ADDRESS=0x...
 WETH_ADDRESS=0x...
 
 USE_FLASHBOTS=false
+ETHERSCAN_API_KEY=your_api_key_here
+AUTO_FETCH_ABI=false
 
 ##############################
 # ⚙️ Performance & Queue

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -23,6 +23,7 @@ export const config = {
   minBalanceBufferEth: parseFloat(process.env.MIN_BALANCE_BUFFER_ETH ?? '0.1'),
   gasMultiplier: parseFloat(process.env.GAS_MULTIPLIER ?? '1.2'),
   mintMaxRetries: parseInt(process.env.MINT_MAX_RETRIES ?? '2', 10),
+  autoFetchAbi: process.env.AUTO_FETCH_ABI === 'true',
 
   // Twitter API Configuration
   twitterClientId: process.env.TWITTER_CLIENT_ID!,

--- a/src/modules/nft_mint_bot/Cargo.lock
+++ b/src/modules/nft_mint_bot/Cargo.lock
@@ -495,6 +495,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "const-hex"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1614,7 +1628,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -2093,6 +2107,8 @@ dependencies = [
  "hyper",
  "once_cell",
  "prometheus",
+ "redis",
+ "reqwest",
  "serde",
  "serde_json",
  "serial_test",
@@ -2666,6 +2682,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "redis"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f49cdc0bb3f412bf8e7d1bd90fe1d9eb10bc5c399ba90973c14662a27b3f8ba"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "combine",
+ "futures-util",
+ "itoa",
+ "percent-encoding",
+ "pin-project-lite",
+ "ryu",
+ "sha1_smol",
+ "socket2 0.4.10",
+ "tokio",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3132,6 +3169,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3209,6 +3252,16 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "socket2"
@@ -3536,7 +3589,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.5.10",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]

--- a/src/modules/nft_mint_bot/Cargo.toml
+++ b/src/modules/nft_mint_bot/Cargo.toml
@@ -9,6 +9,8 @@ tokio = { version = "1", features = ["full"] }
 dotenv = "0.15"
 serde = { version = "1", features = ["derive"] }
 anyhow = "1"
+reqwest = { version = "0.11", features = ["json", "rustls-tls"] }
+redis = { version = "0.23", features = ["tokio-comp"] }
 ethers-flashbots = "0.15"
 url = "2"
 hyper = { version = "0.14", features = ["full"] }

--- a/src/modules/nft_mint_bot/src/abi/etherscan.rs
+++ b/src/modules/nft_mint_bot/src/abi/etherscan.rs
@@ -1,0 +1,152 @@
+use anyhow::{anyhow, Result};
+use ethers::abi::Abi;
+use redis::AsyncCommands;
+use reqwest::{Client, StatusCode};
+use serde::Deserialize;
+use std::env;
+use tokio::time::{sleep, Duration};
+
+#[derive(Deserialize)]
+struct EtherscanResponse {
+    status: String,
+    result: String,
+}
+
+const CACHE_TTL: usize = 60 * 60; // 1 hour
+
+async fn fetch_with_retry(client: &Client, url: &str) -> Result<String> {
+    let mut delay = 1u64;
+    for _ in 0..5 {
+        match client.get(url).send().await {
+            Ok(resp) => {
+                if resp.status() == StatusCode::TOO_MANY_REQUESTS {
+                    sleep(Duration::from_secs(delay)).await;
+                    delay *= 2;
+                    continue;
+                }
+                if resp.status().is_success() {
+                    return Ok(resp.text().await?);
+                } else {
+                    let status = resp.status();
+                    let text = resp.text().await.unwrap_or_default();
+                    return Err(anyhow!("HTTP {}: {}", status, text));
+                }
+            }
+            Err(e) => {
+                if delay < 32 {
+                    sleep(Duration::from_secs(delay)).await;
+                    delay *= 2;
+                } else {
+                    return Err(e.into());
+                }
+            }
+        }
+    }
+    Err(anyhow!("Failed to fetch after retries"))
+}
+
+async fn fetch_from_ipfs(cid: &str) -> Result<Abi> {
+    let cid = cid.trim_start_matches("ipfs://");
+    let url = format!("https://ipfs.io/ipfs/{}", cid);
+    let client = Client::new();
+    let body = fetch_with_retry(&client, &url).await?;
+    let abi: Abi = serde_json::from_str(&body)?;
+    validate_abi(&abi)?;
+    Ok(abi)
+}
+
+fn validate_abi(abi: &Abi) -> Result<()> {
+    if abi.function("mint").is_ok()
+        || abi.function("mintBatch").is_ok()
+        || abi.function("mintWithSignature").is_ok()
+    {
+        Ok(())
+    } else {
+        Err(anyhow!("ABI missing required mint function"))
+    }
+}
+
+/// Fetch ABI from Etherscan or similar compatible explorer
+pub async fn fetch_abi(address: &str, network: &str) -> Result<Abi> {
+    if address.starts_with("ipfs://") {
+        return fetch_from_ipfs(address).await;
+    }
+
+    let api_key = env::var("ETHERSCAN_API_KEY")
+        .map_err(|_| anyhow!("Missing ETHERSCAN_API_KEY in environment"))?;
+
+    let redis_url = env::var("REDIS_URL").unwrap_or_else(|_| "redis://localhost:6379".into());
+    let cache_key = format!("abi:{}:{}", network, address.to_lowercase());
+
+    if let Ok(client) = redis::Client::open(redis_url.clone()) {
+        if let Ok(mut conn) = client.get_async_connection().await {
+            if let Ok(cached) = conn.get::<_, String>(&cache_key).await {
+                if !cached.is_empty() {
+                    if let Ok(abi) = serde_json::from_str(&cached) {
+                        return Ok(abi);
+                    }
+                }
+            }
+        }
+    }
+
+    let base_url = match network.to_lowercase().as_str() {
+        "sepolia" => "https://api-sepolia.etherscan.io",
+        "mainnet" | "ethereum" => "https://api.etherscan.io",
+        "polygon" | "matic" => "https://api.polygonscan.com",
+        "arbitrum" => "https://api.arbiscan.io",
+        "optimism" => "https://api-optimistic.etherscan.io",
+        "base" => "https://api.basescan.org",
+        _ => return Err(anyhow!("Unsupported network")),
+    };
+
+    let url = format!(
+        "{}/api?module=contract&action=getabi&address={}&apikey={}",
+        base_url, address, api_key
+    );
+
+    let client = Client::new();
+    let body = fetch_with_retry(&client, &url).await?;
+    let res: EtherscanResponse = serde_json::from_str(&body)?;
+    if res.status == "1" {
+        let abi: Abi = serde_json::from_str(&res.result)?;
+        validate_abi(&abi)?;
+        if let Ok(redis_client) = redis::Client::open(redis_url) {
+            if let Ok(mut conn) = redis_client.get_async_connection().await {
+                let _: Result<(), _> = conn.set_ex(&cache_key, res.result, CACHE_TTL).await;
+            }
+        }
+        Ok(abi)
+    } else {
+        // attempt fallbacks
+        let mut last_err = anyhow!("Etherscan error: {}", res.result);
+        let fallbacks: Vec<Option<String>> = vec![
+            env::var("ALCHEMY_EXPLORER_URL").ok(),
+            env::var("ANKR_EXPLORER_URL").ok(),
+        ];
+        for fb in fallbacks.into_iter().flatten() {
+            let url = format!(
+                "{}/api?module=contract&action=getabi&address={}&apikey={}",
+                fb, address, api_key
+            );
+            if let Ok(body) = fetch_with_retry(&client, &url).await {
+                if let Ok(res) = serde_json::from_str::<EtherscanResponse>(&body) {
+                    if res.status == "1" {
+                        let abi: Abi = serde_json::from_str(&res.result)?;
+                        validate_abi(&abi)?;
+                        if let Ok(redis_client) = redis::Client::open(redis_url.clone()) {
+                            if let Ok(mut conn) = redis_client.get_async_connection().await {
+                                let _: Result<(), _> =
+                                    conn.set_ex(&cache_key, res.result, CACHE_TTL).await;
+                            }
+                        }
+                        return Ok(abi);
+                    } else {
+                        last_err = anyhow!("{} error: {}", fb, res.result);
+                    }
+                }
+            }
+        }
+        Err(last_err)
+    }
+}

--- a/src/modules/nft_mint_bot/src/abi/mod.rs
+++ b/src/modules/nft_mint_bot/src/abi/mod.rs
@@ -1,0 +1,8 @@
+pub mod etherscan;
+
+use ethers::abi::Abi;
+use anyhow::Result;
+
+pub async fn auto_fetch_abi(address: &str, network: &str) -> Result<Abi> {
+    etherscan::fetch_abi(address, network).await
+}

--- a/src/modules/nft_mint_bot/src/config.rs
+++ b/src/modules/nft_mint_bot/src/config.rs
@@ -9,6 +9,7 @@ pub struct Config {
     pub use_flashbots: bool,
     pub gas_limit: Option<u64>,
     pub gas_multiplier: f64,
+    pub auto_fetch_abi: Option<bool>,
 
 }
 
@@ -54,6 +55,7 @@ impl Config {
                 .unwrap_or_else(|_| "1.0".into())
                 .parse()
                 .expect("invalid GAS_MULTIPLIER"),
+            auto_fetch_abi: env::var("AUTO_FETCH_ABI").ok().map(|v| v.to_lowercase() == "true"),
 
         }
     }

--- a/src/modules/nft_mint_bot/src/lib.rs
+++ b/src/modules/nft_mint_bot/src/lib.rs
@@ -2,5 +2,6 @@ pub mod config;
 pub mod metrics;
 pub mod provider_pool;
 pub mod gas;
+pub mod abi;
 
 

--- a/src/modules/nft_mint_bot/src/main.rs
+++ b/src/modules/nft_mint_bot/src/main.rs
@@ -2,11 +2,13 @@ mod config;
 mod gas;
 mod metrics;
 mod provider_pool;
+mod abi;
 
 use anyhow::{anyhow, Result};
 use clap::{Parser, ValueEnum};
 use config::Config;
 use ethers::abi::{Abi, AbiParser};
+use crate::abi::auto_fetch_abi;
 use ethers::prelude::*;
 use gas::estimate_gas_limit;
 use hex::decode;
@@ -95,6 +97,8 @@ async fn main() -> Result<()> {
     let abi: Abi = if let Some(path) = cli.abi.as_deref() {
         let data = fs::read_to_string(path)?;
         serde_json::from_str(&data)?
+    } else if cfg.auto_fetch_abi.unwrap_or(false) {
+        auto_fetch_abi(&contract_addr_str, "sepolia").await?
     } else {
         AbiParser::default().parse_str(DEFAULT_ABI)?
     };

--- a/src/modules/nft_mint_bot/tests/config.rs
+++ b/src/modules/nft_mint_bot/tests/config.rs
@@ -11,6 +11,7 @@ fn loads_env_vars() {
     env::set_var("USE_FLASHBOTS", "true");
     env::set_var("MINT_GAS_LIMIT", "123456");
     env::set_var("GAS_MULTIPLIER", "1.5");
+    env::set_var("AUTO_FETCH_ABI", "true");
     
     let cfg = Config::load();
     
@@ -23,9 +24,11 @@ fn loads_env_vars() {
     assert!(cfg.use_flashbots);
     assert_eq!(cfg.gas_limit, Some(123456));
     assert_eq!(cfg.gas_multiplier, 1.5);
+    assert_eq!(cfg.auto_fetch_abi, Some(true));
     env::remove_var("PRIMARY_RPC_URL");
     env::remove_var("SECONDARY_RPC_URL");
     env::remove_var("TERTIARY_RPC_URL");
+    env::remove_var("AUTO_FETCH_ABI");
 }
 
 #[test]
@@ -37,6 +40,7 @@ fn loads_env_vars_without_flashbots() {
     env::remove_var("USE_FLASHBOTS"); // Ensure it's not set
     env::set_var("MINT_GAS_LIMIT", "654321");
     env::set_var("GAS_MULTIPLIER", "2.0");
+    env::remove_var("AUTO_FETCH_ABI");
     
     let cfg = Config::load();
     
@@ -49,6 +53,7 @@ fn loads_env_vars_without_flashbots() {
     assert!(!cfg.use_flashbots); // Should default to false
     assert_eq!(cfg.gas_limit, Some(654321));
     assert_eq!(cfg.gas_multiplier, 2.0);
+    assert_eq!(cfg.auto_fetch_abi, None);
     env::remove_var("PRIMARY_RPC_URL");
     env::remove_var("SECONDARY_RPC_URL");
     env::remove_var("TERTIARY_RPC_URL");
@@ -63,6 +68,7 @@ fn loads_multiple_rpc_urls() {
     env::set_var("PRIVATE_KEY", "ghi789");
     env::set_var("CONTRACT_ADDRESS", "0x2222222222222222222222222222222222222222");
     env::set_var("USE_FLASHBOTS", "false");
+    env::remove_var("AUTO_FETCH_ABI");
     
     let cfg = Config::load();
     
@@ -77,6 +83,7 @@ fn loads_multiple_rpc_urls() {
         Some("0x2222222222222222222222222222222222222222")
     );
     assert!(!cfg.use_flashbots);
+    assert_eq!(cfg.auto_fetch_abi, None);
 
     env::remove_var("PRIMARY_RPC_URL");
     env::remove_var("SECONDARY_RPC_URL");


### PR DESCRIPTION
## Summary
- expand abi fetcher network support
- clean up unused field in `EtherscanResponse`

## Testing
- `scripts/run-tests.sh` *(fails: Environment variable not found: DATABASE_URL)*
- `cargo test --manifest-path src/modules/nft_mint_bot/Cargo.toml` *(fails: couldn't read tests/../abi/basicmint.abi.json)*

------
https://chatgpt.com/codex/tasks/task_e_684e9ce3fdac83309ad63d74e7106930